### PR TITLE
Add per-stage power transmission type filters to ratio finder

### DIFF
--- a/app/lib/math/ratioFinder.worker.test.ts
+++ b/app/lib/math/ratioFinder.worker.test.ts
@@ -1,7 +1,53 @@
 import { describe, expect, it } from 'vitest';
 
+import type { FindGearboxesFilters } from '~/lib/math/ratioFinder.worker';
 import { findGearboxes } from '~/lib/math/ratioFinder.worker';
 import Ratio, { RatioType } from '~/lib/models/Ratio';
+import type { StageFamily } from '~/lib/types/common';
+
+const baseFilters: FindGearboxesFilters = {
+  enableREV: true,
+  enableWCP: true,
+  enableAM: true,
+  enableTTB: true,
+  enableLastAnvil: true,
+  enableSDS: true,
+  enablePlanetaries: true,
+  enable20DP: true,
+  enable32DP: true,
+  enableGT2: true,
+  enableHTD: true,
+  enableRT25: true,
+  enable25Chain: true,
+  enable35Chain: true,
+  enableBore12Hex: true,
+  enableBore38Hex: true,
+  enableBore1125: true,
+  enableBoreMAXSpline: true,
+  enableBoreSplineXL: true,
+  enableBore5mmHex: true,
+  enableBore14Round: true,
+  enableCustomGears: false,
+  enableCustomPulleys: false,
+  enableCustomSprockets: false,
+  minGearTeeth: 6,
+  maxGearTeeth: 84,
+  minPulleyTeeth: 8,
+  maxPulleyTeeth: 84,
+  minSprocketTeeth: 8,
+  maxSprocketTeeth: 84,
+};
+
+/** Maps the user-facing stage family to the internal SkuInfo.family value. */
+const SKU_FAMILY: Record<StageFamily, string> = {
+  Gear: 'Gear',
+  Belt: 'Pulley',
+  Chain: 'Sprocket',
+  Planetary: 'Planetary',
+};
+
+const allowedSkuFamilies = (families: StageFamily[]): Set<string> =>
+  new Set(families.map((family) => SKU_FAMILY[family]));
 
 describe('ratioFinderWorker', () => {
   it('should find gearboxes with default settings', async () => {
@@ -9,40 +55,100 @@ describe('ratioFinderWorker', () => {
       new Ratio(20, RatioType.REDUCTION),
       0.25,
       'SplineXS',
-      {
-        enableREV: true,
-        enableWCP: true,
-        enableAM: true,
-        enableTTB: true,
-        enableLastAnvil: true,
-        enableSDS: true,
-        enablePlanetaries: true,
-        enable20DP: true,
-        enable32DP: true,
-        enableGT2: true,
-        enableHTD: true,
-        enableRT25: true,
-        enable25Chain: true,
-        enable35Chain: true,
-        enableBore12Hex: true,
-        enableBore38Hex: true,
-        enableBore1125: true,
-        enableBoreMAXSpline: true,
-        enableBoreSplineXL: true,
-        enableBore5mmHex: true,
-        enableBore14Round: true,
-        enableCustomGears: false,
-        enableCustomPulleys: false,
-        enableCustomSprockets: false,
-        minGearTeeth: 6,
-        maxGearTeeth: 84,
-        minPulleyTeeth: 8,
-        maxPulleyTeeth: 84,
-        minSprocketTeeth: 8,
-        maxSprocketTeeth: 84,
-      },
+      baseFilters,
     );
 
     expect(result).toMatchSnapshot();
   }, 10_000);
+
+  it('omitting stageConstraints matches an empty stageConstraints exactly', async () => {
+    const target = new Ratio(20, RatioType.REDUCTION);
+    const withoutField = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+    });
+    const withEmpty = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+      stageConstraints: [],
+    });
+
+    expect(withEmpty).toEqual(withoutField);
+  }, 10_000);
+
+  it('restricts the first stage to a single transmission family', async () => {
+    const result = await findGearboxes(
+      new Ratio(20, RatioType.REDUCTION),
+      0.25,
+      'SplineXS',
+      { ...baseFilters, stageConstraints: [['Gear'], []] },
+    );
+
+    expect(result.solutions.length).toBeGreaterThan(0);
+    const allowed = allowedSkuFamilies(['Gear']);
+    for (const solution of result.solutions) {
+      const firstStage = solution.stages[0];
+      for (const sku of [...firstStage.from.skus, ...firstStage.to.skus]) {
+        expect(allowed.has(sku.family)).toBe(true);
+      }
+    }
+  }, 10_000);
+
+  it('constrains each stage positionally (gears then chain)', async () => {
+    const result = await findGearboxes(
+      new Ratio(20, RatioType.REDUCTION),
+      0.25,
+      'SplineXS',
+      { ...baseFilters, stageConstraints: [['Gear'], ['Chain']] },
+    );
+
+    expect(result.solutions.length).toBeGreaterThan(0);
+    const stageAllowed = [
+      allowedSkuFamilies(['Gear']),
+      allowedSkuFamilies(['Chain']),
+    ];
+    let sawTwoStage = false;
+    for (const solution of result.solutions) {
+      solution.stages.forEach((stage, index) => {
+        if (index === 1) {
+          sawTwoStage = true;
+        }
+        for (const sku of [...stage.from.skus, ...stage.to.skus]) {
+          expect(stageAllowed[index].has(sku.family)).toBe(true);
+        }
+      });
+    }
+    // A single gear stage cannot reach 20:1 within the tooth range, so every
+    // solution must be a two-stage gear -> chain gearbox.
+    expect(sawTwoStage).toBe(true);
+  }, 10_000);
+
+  it('an empty per-stage list leaves that stage unconstrained', async () => {
+    const target = new Ratio(20, RatioType.REDUCTION);
+    const stage2AnyExplicit = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+      stageConstraints: [['Gear'], []],
+    });
+    const stage2AnyAllFamilies = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+      stageConstraints: [['Gear'], ['Gear', 'Belt', 'Chain', 'Planetary']],
+    });
+
+    expect(stage2AnyExplicit).toEqual(stage2AnyAllFamilies);
+  }, 10_000);
+
+  it('narrowing a stage never yields more solutions than leaving it open', async () => {
+    const target = new Ratio(20, RatioType.REDUCTION);
+    const unconstrained = await findGearboxes(
+      target,
+      0.25,
+      'SplineXS',
+      baseFilters,
+    );
+    const gearsOnly = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+      stageConstraints: [['Gear'], ['Gear']],
+    });
+
+    expect(gearsOnly.count).toBeLessThanOrEqual(unconstrained.count);
+    expect(gearsOnly.count).toBeGreaterThan(0);
+  }, 15_000);
 });

--- a/app/lib/math/ratioFinder.worker.ts
+++ b/app/lib/math/ratioFinder.worker.ts
@@ -6,7 +6,12 @@ import Pulley from '~/lib/models/Pulley';
 import type { RatioDict } from '~/lib/models/Ratio';
 import Ratio from '~/lib/models/Ratio';
 import Sprocket from '~/lib/models/Sprocket';
-import { type Bore, type Vendor, zBoreSchema } from '~/lib/types/common';
+import {
+  type Bore,
+  type StageFamily,
+  type Vendor,
+  zBoreSchema,
+} from '~/lib/types/common';
 import type { JSONGear } from '~/lib/types/gears';
 import type { JSONPlanetaryInstance } from '~/lib/types/planetary';
 import type { JSONPulley } from '~/lib/types/pulleys';
@@ -60,6 +65,15 @@ export interface FindGearboxesFilters {
   enableCustomPulleys: boolean;
   enableCustomSprockets: boolean;
   enablePlanetaries: boolean;
+
+  /**
+   * Per-stage transmission-family constraints, applied positionally. Index 0
+   * restricts the first stage, index 1 the second; the stage count itself is
+   * still discovered automatically. Each inner array lists the families allowed
+   * for that stage, and an absent or empty entry leaves that stage open to any
+   * family. When omitted entirely the finder behaves exactly as before.
+   */
+  stageConstraints?: StageFamily[][];
 }
 
 interface SkuInfo {
@@ -430,6 +444,21 @@ export async function findGearboxes(
   const withinErrorThreshold = (ratio: number, targetRatio: number) => {
     return Math.abs(ratio - targetRatio) <= targetReductionErrorThreshold;
   };
+
+  // Per-stage transmission-family filter applied positionally: stage index 0 is
+  // governed by stageConstraints[0], index 1 by stageConstraints[1]. The stage
+  // count is still discovered automatically (1- and 2-stage solutions are both
+  // enumerated), so a 1-stage solution only needs to satisfy the first stage's
+  // filter. An absent or empty entry leaves that stage open to any family, so
+  // the default (no constraints) preserves the original behavior exactly.
+  const stageConstraints = filters.stageConstraints ?? [];
+  const stageAllowsFamily = (stageIndex: number, family: StageFamily) => {
+    const allowed = stageConstraints[stageIndex];
+    return (
+      allowed === undefined || allowed.length === 0 || allowed.includes(family)
+    );
+  };
+
   for (const [tooth1, tooth2, ratio] of allValidStagesWithRatios) {
     if (tooth1 === tooth2) {
       continue;
@@ -722,12 +751,14 @@ export async function findGearboxes(
 
   for (const maybeSolution of maybeSolutions) {
     for (const [index, stage] of maybeSolution.stages.entries()) {
-      const maybe20DPGears = stageFrom20DPGears(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allGears,
-      );
+      const maybe20DPGears = stageAllowsFamily(index, 'Gear')
+        ? stageFrom20DPGears(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allGears,
+          )
+        : null;
       if (maybe20DPGears) {
         const [driving, driven] = maybe20DPGears;
 
@@ -735,12 +766,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((g) => skuInfoMap.get(g.sku!)!));
       }
 
-      const maybe32DPGears = stageFrom32DPGears(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allGears,
-      );
+      const maybe32DPGears = stageAllowsFamily(index, 'Gear')
+        ? stageFrom32DPGears(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allGears,
+          )
+        : null;
       if (maybe32DPGears) {
         const [driving, driven] = maybe32DPGears;
 
@@ -748,12 +781,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((g) => skuInfoMap.get(g.sku!)!));
       }
 
-      const maybeGT2Pulleys = stageFromGT2Pulleys(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allPulleys,
-      );
+      const maybeGT2Pulleys = stageAllowsFamily(index, 'Belt')
+        ? stageFromGT2Pulleys(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allPulleys,
+          )
+        : null;
       if (maybeGT2Pulleys) {
         const [driving, driven] = maybeGT2Pulleys;
 
@@ -761,12 +796,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((p) => skuInfoMap.get(p.sku!)!));
       }
 
-      const maybeHTDPulleys = stageFromHTDPulleys(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allPulleys,
-      );
+      const maybeHTDPulleys = stageAllowsFamily(index, 'Belt')
+        ? stageFromHTDPulleys(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allPulleys,
+          )
+        : null;
       if (maybeHTDPulleys) {
         const [driving, driven] = maybeHTDPulleys;
 
@@ -774,12 +811,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((p) => skuInfoMap.get(p.sku!)!));
       }
 
-      const maybe25ChainSprockets = stageFrom25ChainSprockets(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allSprockets,
-      );
+      const maybe25ChainSprockets = stageAllowsFamily(index, 'Chain')
+        ? stageFrom25ChainSprockets(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allSprockets,
+          )
+        : null;
       if (maybe25ChainSprockets) {
         const [driving, driven] = maybe25ChainSprockets;
 
@@ -787,12 +826,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((s) => skuInfoMap.get(s.sku!)!));
       }
 
-      const maybe35ChainSprockets = stageFrom35ChainSprockets(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allSprockets,
-      );
+      const maybe35ChainSprockets = stageAllowsFamily(index, 'Chain')
+        ? stageFrom35ChainSprockets(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allSprockets,
+          )
+        : null;
       if (maybe35ChainSprockets) {
         const [driving, driven] = maybe35ChainSprockets;
 
@@ -800,12 +841,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((s) => skuInfoMap.get(s.sku!)!));
       }
 
-      const maybePlanetaries = stageFromPlanetaries(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allPlanetaries,
-      );
+      const maybePlanetaries = stageAllowsFamily(index, 'Planetary')
+        ? stageFromPlanetaries(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allPlanetaries,
+          )
+        : null;
       if (maybePlanetaries) {
         stage.from.skus.push(
           ...maybePlanetaries.map(

--- a/app/lib/types/common.ts
+++ b/app/lib/types/common.ts
@@ -36,6 +36,15 @@ export const VENDOR_NAMES = [
 export type Vendor = (typeof VENDOR_NAMES)[number];
 export const zVendorSchema = z.enum(VENDOR_NAMES);
 
+/**
+ * User-facing power-transmission families selectable per ratio-finder stage.
+ * These map onto the internal {@link SkuInfo} families as follows:
+ *   Gear -> 'Gear', Belt -> 'Pulley', Chain -> 'Sprocket', Planetary -> 'Planetary'.
+ */
+export const STAGE_FAMILIES = ['Gear', 'Belt', 'Chain', 'Planetary'] as const;
+export const zStageFamilySchema = z.enum(STAGE_FAMILIES);
+export type StageFamily = z.infer<typeof zStageFamilySchema>;
+
 export type StateHook<T> = [T, Dispatch<SetStateAction<T>>];
 
 export type HasStateHook<T> = {

--- a/app/lib/types/queryParams.ts
+++ b/app/lib/types/queryParams.ts
@@ -4,11 +4,13 @@ import {
   parseAsFloat,
   parseAsString,
 } from 'nuqs';
+import * as z from 'zod';
 
 import Measurement from '~/lib/models/Measurement';
 import Motor from '~/lib/models/Motor';
 import Ratio, { RatioType } from '~/lib/models/Ratio';
-import type { Bore } from '~/lib/types/common';
+import type { Bore, StageFamily } from '~/lib/types/common';
+import { zStageFamilySchema } from '~/lib/types/common';
 
 export const StringParam = parseAsString;
 
@@ -81,6 +83,28 @@ export const RatioPairListParam = createParser<RatioPair[]>({
         return parsed;
       }
       return null;
+    } catch {
+      return null;
+    }
+  },
+  serialize(value) {
+    return JSON.stringify(value);
+  },
+});
+
+/**
+ * Per-stage transmission-family constraints for the ratio finder, applied
+ * positionally (index 0 = stage 1, index 1 = stage 2). Each inner array lists
+ * the families allowed for that stage; an empty inner array means "any family".
+ * The stage count is not encoded here -- it is still discovered automatically.
+ */
+const zStageConstraintsSchema = z.array(z.array(zStageFamilySchema));
+
+export const StageConstraintListParam = createParser<StageFamily[][]>({
+  parse(value) {
+    try {
+      const result = zStageConstraintsSchema.safeParse(JSON.parse(value));
+      return result.success ? result.data : null;
     } catch {
       return null;
     }

--- a/app/routes/ratio-finder.tsx
+++ b/app/routes/ratio-finder.tsx
@@ -1,3 +1,4 @@
+import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 
@@ -8,16 +9,20 @@ import BoreInput from '~/components/recalc/io/bore';
 import CheckboxBooleanInput from '~/components/recalc/io/checkboxBoolean';
 import NumberInput from '~/components/recalc/io/number';
 import { RatioInput } from '~/components/recalc/io/ratio';
+import { Checkbox } from '~/components/ui/checkbox';
+import { Label } from '~/components/ui/label';
 import { Spinner } from '~/components/ui/spinner';
 import { useQueryParams, useSerializedState } from '~/lib/hooks';
 import type * as RatioFinderWorker from '~/lib/math/ratioFinder.worker';
 import Ratio, { RatioType } from '~/lib/models/Ratio';
-import type { Bore } from '~/lib/types/common';
+import type { Bore, StageFamily } from '~/lib/types/common';
+import { STAGE_FAMILIES } from '~/lib/types/common';
 import {
   BooleanParam,
   BoreParam,
   NumberParam,
   RatioParam,
+  StageConstraintListParam,
 } from '~/lib/types/queryParams';
 
 export function meta() {
@@ -61,6 +66,8 @@ const DEFAULT_PARAMS = {
   enableCustomPulleys: BooleanParam.withDefault(false),
   enableCustomSprockets: BooleanParam.withDefault(false),
   startingBore: BoreParam.withDefault('SplineXS' as Bore),
+  // Empty array == "Auto" (unconstrained stage count and per-stage type).
+  stageConstraints: StageConstraintListParam.withDefault([]),
 };
 
 const worker = new ComlinkWorker<typeof RatioFinderWorker>(
@@ -142,6 +149,24 @@ export default function RatioFinder() {
   );
   const [startingBore, setStartingBore] = useState(queryParams.startingBore);
 
+  // Per-stage transmission-type filters. These are positional: the Stage 1
+  // filter applies to every solution's first stage, the Stage 2 filter only to
+  // 2-stage solutions. Each defaults to all families, so the finder behaves
+  // exactly as before until the user narrows a stage. A stage with no families
+  // selected is treated as "any type".
+  const initialStageConstraints = queryParams.stageConstraints;
+  const [stage1Families, setStage1Families] = useState<StageFamily[]>(
+    initialStageConstraints[0] ?? [...STAGE_FAMILIES],
+  );
+  const [stage2Families, setStage2Families] = useState<StageFamily[]>(
+    initialStageConstraints[1] ?? [...STAGE_FAMILIES],
+  );
+
+  const stageConstraints = useMemo<StageFamily[][]>(
+    () => [stage1Families, stage2Families],
+    [stage1Families, stage2Families],
+  );
+
   const [solutions, setSolutions] = useState<
     RatioFinderWorker.GearboxSolution[]
   >([]);
@@ -180,6 +205,7 @@ export default function RatioFinder() {
       enableCustomGears,
       enableCustomPulleys,
       enableCustomSprockets,
+      stageConstraints,
     }),
     [
       minGearTeeth,
@@ -212,10 +238,17 @@ export default function RatioFinder() {
       enableCustomGears,
       enableCustomPulleys,
       enableCustomSprockets,
+      stageConstraints,
     ],
   );
 
   useEffect(() => {
+    // findGearboxes is async (it awaits dynamic data imports), so successive
+    // calls interleave inside the worker and may resolve out of order. Ignore
+    // any response that arrives after the inputs have changed so a slower,
+    // stale request can never overwrite the latest results.
+    let cancelled = false;
+
     setCount(0);
     setSolutions([]);
     setLoading(true);
@@ -228,16 +261,26 @@ export default function RatioFinder() {
         filters,
       )
       .then((results) => {
+        if (cancelled) {
+          return;
+        }
         setCount(results.count);
         setSolutions(results.solutions);
         setLoading(false);
       })
       .catch((error) => {
+        if (cancelled) {
+          return;
+        }
         console.error(error);
         setSolutions([]);
         setCount(0);
         setLoading(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [targetReduction, targetReductionErrorThreshold, startingBore, filters]);
 
   const serializedState = useSerializedState(DEFAULT_PARAMS, {
@@ -274,6 +317,7 @@ export default function RatioFinder() {
     enableCustomPulleys,
     enableCustomSprockets,
     startingBore,
+    stageConstraints,
   });
 
   return (
@@ -495,6 +539,31 @@ export default function RatioFinder() {
                 </div>
               </div>
             </div>
+            <div className="border-t" />
+
+            <div className="flex flex-col gap-3 p-4">
+              <h2 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                Transmission Type Per Stage
+              </h2>
+              <p className="text-xs text-muted-foreground">
+                Restrict which power transmission types each stage may use. The
+                Stage 2 filter only affects two-stage solutions.
+              </p>
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                <StageFamilySelect
+                  families={stage1Families}
+                  setFamilies={setStage1Families}
+                  label="Stage 1"
+                  testId="stage-1-families"
+                />
+                <StageFamilySelect
+                  families={stage2Families}
+                  setFamilies={setStage2Families}
+                  label="Stage 2"
+                  testId="stage-2-families"
+                />
+              </div>
+            </div>
           </section>
         </div>
 
@@ -511,6 +580,59 @@ export default function RatioFinder() {
       </div>
     </div>
   );
+}
+
+function StageFamilySelect({
+  families,
+  setFamilies,
+  label,
+  testId,
+}: {
+  families: StageFamily[];
+  setFamilies: Dispatch<SetStateAction<StageFamily[]>>;
+  label: string;
+  testId?: string;
+}) {
+  // Use a functional update so rapid successive toggles each compose on the
+  // latest selection rather than a value captured at render time.
+  const toggle = (family: StageFamily, checked: boolean) => {
+    setFamilies((prev) =>
+      checked ? [...prev, family] : prev.filter((f) => f !== family),
+    );
+  };
+
+  return (
+    <div className="rounded-lg border bg-card p-3" data-testid={testId}>
+      <h3 className="mb-2 text-center text-sm font-semibold text-muted-foreground">
+        {label}
+      </h3>
+      <div className="flex flex-col gap-2">
+        {STAGE_FAMILIES.map((family) => (
+          <div key={family} className="flex flex-row items-center gap-2">
+            <Checkbox
+              aria-label={`${label} ${family}`}
+              checked={families.includes(family)}
+              onCheckedChange={(checked) => toggle(family, checked === true)}
+            />
+            <Label>{family}</Label>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Human-facing transmission family for a matched SKU. */
+function skuFamilyLabel(
+  family: 'Gear' | 'Pulley' | 'Sprocket' | 'Planetary',
+): string {
+  if (family === 'Pulley') {
+    return 'Belt';
+  }
+  if (family === 'Sprocket') {
+    return 'Chain';
+  }
+  return family;
 }
 
 export function GearboxList({
@@ -538,7 +660,7 @@ export function GearboxList({
     return pitch;
   };
   return (
-    <div className="w-full">
+    <div className="w-full" data-testid="gearbox-list">
       <div className="overflow-hidden rounded-lg border bg-card">
         <div className="overflow-x-auto">
           <table className="w-full">
@@ -581,61 +703,81 @@ export function GearboxList({
                   </td>
                   <td className="px-3 py-3">
                     <div className="space-y-2">
-                      {gearbox.stages.map((stage, stageIndex) => (
-                        <div key={stageIndex} className="text-xs">
-                          <div className="mb-1 font-medium text-muted-foreground">
-                            Stage {stageIndex + 1}
-                          </div>
-                          <div className="grid grid-cols-2 gap-2">
-                            <div className="space-y-1">
-                              <div className="text-[10px] tracking-wide text-muted-foreground uppercase">
-                                {stage.from.teeth}T
-                              </div>
-                              {stage.from.skus.map((sku, skuIndex) => (
-                                <Link
-                                  key={skuIndex}
-                                  to={sku.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="block rounded border border-border bg-muted/50 p-1.5 text-[11px] transition-colors hover:bg-muted"
-                                >
-                                  <span className="font-semibold">
-                                    {sku.sku}
-                                  </span>
-                                  <span className="text-muted-foreground">
-                                    {' '}
-                                    - {formatPitch(sku.pitch, sku.family)}{' '}
-                                    {sku.family} ({sku.bore})
-                                  </span>
-                                </Link>
-                              ))}
+                      {gearbox.stages.map((stage, stageIndex) => {
+                        const stageFamilies = [
+                          ...new Set(
+                            [...stage.from.skus, ...stage.to.skus].map((sku) =>
+                              skuFamilyLabel(sku.family),
+                            ),
+                          ),
+                        ];
+                        return (
+                          <div key={stageIndex} className="text-xs">
+                            <div className="mb-1 font-medium text-muted-foreground">
+                              Stage {stageIndex + 1}
+                              {stageFamilies.length > 0 && (
+                                <span className="ml-1 font-normal">
+                                  ({stageFamilies.join(', ')})
+                                </span>
+                              )}
                             </div>
-                            <div className="space-y-1">
-                              <div className="text-[10px] tracking-wide text-muted-foreground uppercase">
-                                {stage.to.teeth}T
+                            <div className="grid grid-cols-2 gap-2">
+                              <div className="space-y-1">
+                                <div className="text-[10px] tracking-wide text-muted-foreground uppercase">
+                                  {stage.from.teeth}T
+                                </div>
+                                {stage.from.skus.map((sku, skuIndex) => (
+                                  <Link
+                                    key={skuIndex}
+                                    to={sku.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="block rounded border border-border bg-muted/50 p-1.5 text-[11px] transition-colors hover:bg-muted"
+                                  >
+                                    <span className="font-semibold">
+                                      {sku.sku}
+                                    </span>
+                                    <span className="text-muted-foreground">
+                                      {' '}
+                                      - {formatPitch(
+                                        sku.pitch,
+                                        sku.family,
+                                      )}{' '}
+                                      {sku.family} ({sku.bore})
+                                    </span>
+                                  </Link>
+                                ))}
                               </div>
-                              {stage.to.skus.map((sku, skuIndex) => (
-                                <Link
-                                  key={skuIndex}
-                                  to={sku.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="block rounded border border-border bg-muted/50 p-1.5 text-[11px] transition-colors hover:bg-muted"
-                                >
-                                  <span className="font-semibold">
-                                    {sku.sku}
-                                  </span>
-                                  <span className="text-muted-foreground">
-                                    {' '}
-                                    - {formatPitch(sku.pitch, sku.family)}{' '}
-                                    {sku.family} ({sku.bore})
-                                  </span>
-                                </Link>
-                              ))}
+                              <div className="space-y-1">
+                                <div className="text-[10px] tracking-wide text-muted-foreground uppercase">
+                                  {stage.to.teeth}T
+                                </div>
+                                {stage.to.skus.map((sku, skuIndex) => (
+                                  <Link
+                                    key={skuIndex}
+                                    to={sku.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="block rounded border border-border bg-muted/50 p-1.5 text-[11px] transition-colors hover:bg-muted"
+                                  >
+                                    <span className="font-semibold">
+                                      {sku.sku}
+                                    </span>
+                                    <span className="text-muted-foreground">
+                                      {' '}
+                                      - {formatPitch(
+                                        sku.pitch,
+                                        sku.family,
+                                      )}{' '}
+                                      {sku.family} ({sku.bore})
+                                    </span>
+                                  </Link>
+                                ))}
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                     </div>
                   </td>
                 </tr>

--- a/playwright-tests/ratio-finder.spec.ts
+++ b/playwright-tests/ratio-finder.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const FAMILIES = ['Gear', 'Belt', 'Chain', 'Planetary'] as const;
+
+// The worker loads the full COTS dataset and enumerates thousands of stage
+// combinations, so the first computation can take several seconds.
+const COMPUTE_TIMEOUT = 30_000;
+
+async function waitForResults(page: Page) {
+  await expect(page.getByTestId('gearbox-list')).toBeVisible({
+    timeout: COMPUTE_TIMEOUT,
+  });
+}
+
+test.describe('Ratio Finder - per-stage transmission type', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/ratio-finder');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('per-stage type filters are visible by default and fully selected', async ({
+    page,
+  }) => {
+    // The feature is discoverable without opening any menu.
+    await expect(page.getByTestId('stage-1-families')).toBeVisible();
+    await expect(page.getByTestId('stage-2-families')).toBeVisible();
+
+    for (const stage of ['Stage 1', 'Stage 2']) {
+      for (const family of FAMILIES) {
+        await expect(
+          page.getByRole('checkbox', { name: `${stage} ${family}` }),
+        ).toBeChecked();
+      }
+    }
+  });
+
+  test('restricting both stages to gears removes belt/chain/planetary results', async ({
+    page,
+  }) => {
+    await waitForResults(page);
+    const list = page.getByTestId('gearbox-list');
+
+    for (const stage of ['Stage 1', 'Stage 2']) {
+      for (const family of ['Belt', 'Chain', 'Planetary']) {
+        await page
+          .getByRole('checkbox', { name: `${stage} ${family}` })
+          .click();
+      }
+    }
+
+    // Gears-only solutions must still exist for the default 20:1 target.
+    await expect(list).toContainText('Gear', { timeout: COMPUTE_TIMEOUT });
+    // ...and no belt, chain, or planetary components may appear.
+    await expect(list).not.toContainText('Pulley', {
+      timeout: COMPUTE_TIMEOUT,
+    });
+    await expect(list).not.toContainText('Sprocket', {
+      timeout: COMPUTE_TIMEOUT,
+    });
+    await expect(list).not.toContainText('Planetary', {
+      timeout: COMPUTE_TIMEOUT,
+    });
+  });
+
+  test('stages honor their own type filter positionally (gears then chain)', async ({
+    page,
+  }) => {
+    await waitForResults(page);
+    const list = page.getByTestId('gearbox-list');
+
+    // Stage 1 -> gears only.
+    for (const family of ['Belt', 'Chain', 'Planetary']) {
+      await page.getByRole('checkbox', { name: `Stage 1 ${family}` }).click();
+    }
+    // Stage 2 -> chain only.
+    for (const family of ['Gear', 'Belt', 'Planetary']) {
+      await page.getByRole('checkbox', { name: `Stage 2 ${family}` }).click();
+    }
+
+    // Every resulting two-stage gearbox must run gears into chain. The stage
+    // header renders as "Stage 1(Gear)" (no space before the parenthesis).
+    await expect(list.getByText(/Stage 1\s*\(Gear\)/).first()).toBeVisible({
+      timeout: COMPUTE_TIMEOUT,
+    });
+    await expect(list.getByText(/Stage 2\s*\(Chain\)/).first()).toBeVisible({
+      timeout: COMPUTE_TIMEOUT,
+    });
+    await expect(list.getByText(/Stage 1\s*\([^)]*Belt[^)]*\)/)).toHaveCount(0);
+    await expect(list.getByText(/Stage 2\s*\([^)]*Gear[^)]*\)/)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the ability to restrict which power transmission types each stage of a found gearbox may use in the **Ratio Finder**. A new "Transmission Type Per Stage" section (below the existing Filters) provides two filter cards — **Stage 1** and **Stage 2** — each with checkboxes for **Gear**, **Belt**, **Chain**, and **Planetary**.

For example: require Stage 1 to be gears and Stage 2 to be belt or chain.

## Behavior

- **Positional:** the Stage 1 filter governs every solution's first stage; the Stage 2 filter governs only the second stage of two-stage solutions. The stage count is still discovered automatically (no stage-count picker).
- **Backward compatible:** each filter defaults to all types, and an empty selection means "any type". With defaults, results are byte-for-byte identical to before (verified against the existing worker snapshot).
- **Shareable:** the selection persists in the URL via a new `StageConstraintListParam` (zod-validated), consistent with the page's other nuqs params.

## Bug fix

Also fixes a pre-existing **stale-response race** in the ratio-finder worker effect. `findGearboxes` awaits async data imports, so rapid filter changes let overlapping calls interleave and a slower in-flight call could overwrite newer results. The effect now ignores responses that arrive after its inputs have changed.

## Tests

- 5 new worker unit tests: positional gating (e.g. gears → chain), empty-list = unconstrained, and that omitting the field equals an empty constraint exactly.
- 3 new Playwright tests: filters visible/checked by default, gears-only removes belt/chain/planetary results, and positional gears-then-chain.
- Full suite: 692/692 unit tests pass (snapshot unchanged); lint, format, typecheck, and build all clean.

## Notes

Scoped to the existing 2-stage maximum. Extending to 3+ stages is out of scope here — the enumeration is an `O(N²)` brute force that would become `O(N³)` (~200B iterations on the default tooth range), which is infeasible on the low-power devices this project targets without a smarter pruned search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)