### PR TITLE
Ratio finder: 3-stage gearboxes (auto-fallback) + ~100x faster search

### DIFF
--- a/app/lib/math/__snapshots__/ratioFinder.worker.test.ts.snap
+++ b/app/lib/math/__snapshots__/ratioFinder.worker.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`ratioFinderWorker > should find gearboxes with default settings 1`] = `
 {
+  "autoExpandedToThreeStage": false,
   "count": 3417,
   "solutions": [
     {

--- a/app/lib/math/ratioFinder.worker.test.ts
+++ b/app/lib/math/ratioFinder.worker.test.ts
@@ -151,4 +151,64 @@ describe('ratioFinderWorker', () => {
     expect(gearsOnly.count).toBeLessThanOrEqual(unconstrained.count);
     expect(gearsOnly.count).toBeGreaterThan(0);
   }, 15_000);
+
+  it('defaults to at most two stages', async () => {
+    const result = await findGearboxes(
+      new Ratio(20, RatioType.REDUCTION),
+      0.25,
+      'SplineXS',
+      baseFilters,
+    );
+    expect(result.solutions.every((s) => s.stages.length <= 2)).toBe(true);
+  }, 15_000);
+
+  // With planetaries disabled a single toothed stage tops out near 14:1, so two
+  // stages cannot exceed ~196:1 and a 250:1 target needs exactly three stages.
+  const highRatioFilters = { ...baseFilters, enablePlanetaries: false };
+
+  it('generates three-stage gearboxes for ratios unreachable in two stages', async () => {
+    const result = await findGearboxes(
+      new Ratio(250, RatioType.REDUCTION),
+      5,
+      'SplineXS',
+      highRatioFilters,
+      3,
+    );
+    expect(result.solutions.length).toBeGreaterThan(0);
+    expect(result.solutions.length).toBeLessThanOrEqual(50);
+    for (const s of result.solutions) {
+      expect(s.stages.length).toBe(3);
+      expect(Math.abs(s.ratio - 250)).toBeLessThanOrEqual(5);
+    }
+  }, 30_000);
+
+  it('does not generate three-stage gearboxes for that target when maxStages is 2', async () => {
+    const result = await findGearboxes(
+      new Ratio(250, RatioType.REDUCTION),
+      5,
+      'SplineXS',
+      highRatioFilters,
+    );
+    // Two toothed stages cannot reach 250:1, so there are no solutions.
+    expect(result.solutions.length).toBe(0);
+  }, 15_000);
+
+  it('applies per-stage constraints positionally across three stages', async () => {
+    const result = await findGearboxes(
+      new Ratio(20, RatioType.REDUCTION),
+      0.25,
+      'SplineXS',
+      { ...baseFilters, stageConstraints: [['Gear'], ['Belt'], ['Chain']] },
+      3,
+    );
+    expect(result.solutions.length).toBeGreaterThan(0);
+    const expected = ['Gear', 'Pulley', 'Sprocket'];
+    for (const s of result.solutions) {
+      s.stages.forEach((stage, index) => {
+        for (const sku of [...stage.from.skus, ...stage.to.skus]) {
+          expect(sku.family).toBe(expected[index]);
+        }
+      });
+    }
+  }, 30_000);
 });

--- a/app/lib/math/ratioFinder.worker.test.ts
+++ b/app/lib/math/ratioFinder.worker.test.ts
@@ -152,7 +152,7 @@ describe('ratioFinderWorker', () => {
     expect(gearsOnly.count).toBeGreaterThan(0);
   }, 15_000);
 
-  it('defaults to at most two stages', async () => {
+  it('stays at two stages and does not fall back when two-stage options exist', async () => {
     const result = await findGearboxes(
       new Ratio(20, RatioType.REDUCTION),
       0.25,
@@ -160,50 +160,59 @@ describe('ratioFinderWorker', () => {
       baseFilters,
     );
     expect(result.solutions.every((s) => s.stages.length <= 2)).toBe(true);
+    expect(result.autoExpandedToThreeStage).toBe(false);
   }, 15_000);
 
   // With planetaries disabled a single toothed stage tops out near 14:1, so two
   // stages cannot exceed ~196:1 and a 250:1 target needs exactly three stages.
   const highRatioFilters = { ...baseFilters, enablePlanetaries: false };
 
-  it('generates three-stage gearboxes for ratios unreachable in two stages', async () => {
+  it('auto-falls back to three stages when no one- or two-stage option exists', async () => {
     const result = await findGearboxes(
       new Ratio(250, RatioType.REDUCTION),
       5,
       'SplineXS',
       highRatioFilters,
-      3,
     );
     expect(result.solutions.length).toBeGreaterThan(0);
     expect(result.solutions.length).toBeLessThanOrEqual(50);
+    expect(result.autoExpandedToThreeStage).toBe(true);
     for (const s of result.solutions) {
       expect(s.stages.length).toBe(3);
       expect(Math.abs(s.ratio - 250)).toBeLessThanOrEqual(5);
     }
   }, 30_000);
 
-  it('does not generate three-stage gearboxes for that target when maxStages is 2', async () => {
+  it('does not search three stages when the fallback is disabled (maxStages 2)', async () => {
     const result = await findGearboxes(
       new Ratio(250, RatioType.REDUCTION),
       5,
       'SplineXS',
       highRatioFilters,
+      2,
     );
     // Two toothed stages cannot reach 250:1, so there are no solutions.
     expect(result.solutions.length).toBe(0);
+    expect(result.autoExpandedToThreeStage).toBe(false);
   }, 15_000);
 
-  it('applies per-stage constraints positionally across three stages', async () => {
+  it('applies per-stage constraints positionally across a three-stage fallback', async () => {
+    // gear -> belt is capped near 14 * 10.5 = 147:1, so a 200:1 target with a
+    // gear/belt/chain chain can only be met by falling back to three stages.
     const result = await findGearboxes(
-      new Ratio(20, RatioType.REDUCTION),
-      0.25,
+      new Ratio(200, RatioType.REDUCTION),
+      5,
       'SplineXS',
-      { ...baseFilters, stageConstraints: [['Gear'], ['Belt'], ['Chain']] },
-      3,
+      {
+        ...highRatioFilters,
+        stageConstraints: [['Gear'], ['Belt'], ['Chain']],
+      },
     );
     expect(result.solutions.length).toBeGreaterThan(0);
+    expect(result.autoExpandedToThreeStage).toBe(true);
     const expected = ['Gear', 'Pulley', 'Sprocket'];
     for (const s of result.solutions) {
+      expect(s.stages.length).toBe(3);
       s.stages.forEach((stage, index) => {
         for (const sku of [...stage.from.skus, ...stage.to.skus]) {
           expect(sku.family).toBe(expected[index]);

--- a/app/lib/math/ratioFinder.worker.test.ts
+++ b/app/lib/math/ratioFinder.worker.test.ts
@@ -1,7 +1,53 @@
 import { describe, expect, it } from 'vitest';
 
+import type { FindGearboxesFilters } from '~/lib/math/ratioFinder.worker';
 import { findGearboxes } from '~/lib/math/ratioFinder.worker';
 import Ratio, { RatioType } from '~/lib/models/Ratio';
+import type { StageFamily } from '~/lib/types/common';
+
+const baseFilters: FindGearboxesFilters = {
+  enableREV: true,
+  enableWCP: true,
+  enableAM: true,
+  enableTTB: true,
+  enableLastAnvil: true,
+  enableSDS: true,
+  enablePlanetaries: true,
+  enable20DP: true,
+  enable32DP: true,
+  enableGT2: true,
+  enableHTD: true,
+  enableRT25: true,
+  enable25Chain: true,
+  enable35Chain: true,
+  enableBore12Hex: true,
+  enableBore38Hex: true,
+  enableBore1125: true,
+  enableBoreMAXSpline: true,
+  enableBoreSplineXL: true,
+  enableBore5mmHex: true,
+  enableBore14Round: true,
+  enableCustomGears: false,
+  enableCustomPulleys: false,
+  enableCustomSprockets: false,
+  minGearTeeth: 6,
+  maxGearTeeth: 84,
+  minPulleyTeeth: 8,
+  maxPulleyTeeth: 84,
+  minSprocketTeeth: 8,
+  maxSprocketTeeth: 84,
+};
+
+/** Maps the user-facing stage family to the internal SkuInfo.family value. */
+const SKU_FAMILY: Record<StageFamily, string> = {
+  Gear: 'Gear',
+  Belt: 'Pulley',
+  Chain: 'Sprocket',
+  Planetary: 'Planetary',
+};
+
+const allowedSkuFamilies = (families: StageFamily[]): Set<string> =>
+  new Set(families.map((family) => SKU_FAMILY[family]));
 
 describe('ratioFinderWorker', () => {
   it('should find gearboxes with default settings', async () => {
@@ -9,40 +55,100 @@ describe('ratioFinderWorker', () => {
       new Ratio(20, RatioType.REDUCTION),
       0.25,
       'SplineXS',
-      {
-        enableREV: true,
-        enableWCP: true,
-        enableAM: true,
-        enableTTB: true,
-        enableLastAnvil: true,
-        enableSDS: true,
-        enablePlanetaries: true,
-        enable20DP: true,
-        enable32DP: true,
-        enableGT2: true,
-        enableHTD: true,
-        enableRT25: true,
-        enable25Chain: true,
-        enable35Chain: true,
-        enableBore12Hex: true,
-        enableBore38Hex: true,
-        enableBore1125: true,
-        enableBoreMAXSpline: true,
-        enableBoreSplineXL: true,
-        enableBore5mmHex: true,
-        enableBore14Round: true,
-        enableCustomGears: false,
-        enableCustomPulleys: false,
-        enableCustomSprockets: false,
-        minGearTeeth: 6,
-        maxGearTeeth: 84,
-        minPulleyTeeth: 8,
-        maxPulleyTeeth: 84,
-        minSprocketTeeth: 8,
-        maxSprocketTeeth: 84,
-      },
+      baseFilters,
     );
 
     expect(result).toMatchSnapshot();
   }, 10_000);
+
+  it('omitting stageConstraints matches an empty stageConstraints exactly', async () => {
+    const target = new Ratio(20, RatioType.REDUCTION);
+    const withoutField = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+    });
+    const withEmpty = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+      stageConstraints: [],
+    });
+
+    expect(withEmpty).toEqual(withoutField);
+  }, 10_000);
+
+  it('restricts the first stage to a single transmission family', async () => {
+    const result = await findGearboxes(
+      new Ratio(20, RatioType.REDUCTION),
+      0.25,
+      'SplineXS',
+      { ...baseFilters, stageConstraints: [['Gear'], []] },
+    );
+
+    expect(result.solutions.length).toBeGreaterThan(0);
+    const allowed = allowedSkuFamilies(['Gear']);
+    for (const solution of result.solutions) {
+      const firstStage = solution.stages[0];
+      for (const sku of [...firstStage.from.skus, ...firstStage.to.skus]) {
+        expect(allowed.has(sku.family)).toBe(true);
+      }
+    }
+  }, 10_000);
+
+  it('constrains each stage positionally (gears then chain)', async () => {
+    const result = await findGearboxes(
+      new Ratio(20, RatioType.REDUCTION),
+      0.25,
+      'SplineXS',
+      { ...baseFilters, stageConstraints: [['Gear'], ['Chain']] },
+    );
+
+    expect(result.solutions.length).toBeGreaterThan(0);
+    const stageAllowed = [
+      allowedSkuFamilies(['Gear']),
+      allowedSkuFamilies(['Chain']),
+    ];
+    let sawTwoStage = false;
+    for (const solution of result.solutions) {
+      solution.stages.forEach((stage, index) => {
+        if (index === 1) {
+          sawTwoStage = true;
+        }
+        for (const sku of [...stage.from.skus, ...stage.to.skus]) {
+          expect(stageAllowed[index].has(sku.family)).toBe(true);
+        }
+      });
+    }
+    // A single gear stage cannot reach 20:1 within the tooth range, so every
+    // solution must be a two-stage gear -> chain gearbox.
+    expect(sawTwoStage).toBe(true);
+  }, 10_000);
+
+  it('an empty per-stage list leaves that stage unconstrained', async () => {
+    const target = new Ratio(20, RatioType.REDUCTION);
+    const stage2AnyExplicit = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+      stageConstraints: [['Gear'], []],
+    });
+    const stage2AnyAllFamilies = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+      stageConstraints: [['Gear'], ['Gear', 'Belt', 'Chain', 'Planetary']],
+    });
+
+    expect(stage2AnyExplicit).toEqual(stage2AnyAllFamilies);
+  }, 10_000);
+
+  it('narrowing a stage never yields more solutions than leaving it open', async () => {
+    const target = new Ratio(20, RatioType.REDUCTION);
+    const unconstrained = await findGearboxes(
+      target,
+      0.25,
+      'SplineXS',
+      baseFilters,
+    );
+    const gearsOnly = await findGearboxes(target, 0.25, 'SplineXS', {
+      ...baseFilters,
+      stageConstraints: [['Gear'], ['Gear']],
+    });
+
+    expect(gearsOnly.count).toBeLessThanOrEqual(unconstrained.count);
+    expect(gearsOnly.count).toBeGreaterThan(0);
+  }, 15_000);
 });

--- a/app/lib/math/ratioFinder.worker.ts
+++ b/app/lib/math/ratioFinder.worker.ts
@@ -166,10 +166,14 @@ export async function findGearboxes(
   targetReductionErrorThreshold: number,
   startingBore: Bore,
   filters: FindGearboxesFilters,
-  maxStages = 2,
+  // Ceiling on stages to search. Three-stage gearboxes are only ever returned
+  // as an automatic fallback when no one- or two-stage option exists; pass 2 to
+  // disable that fallback entirely.
+  maxStages = 3,
 ): Promise<{
   count: number;
   solutions: GearboxSolution[];
+  autoExpandedToThreeStage: boolean;
 }> {
   const targetReduction = Ratio.fromDict(targetReduction_);
   const skuInfoMap = new Map<string, SkuInfo>();
@@ -691,7 +695,6 @@ export async function findGearboxes(
 
   const stage0 = candidatesAt(0);
   const stage1 = maxStages >= 2 ? candidatesAt(1) : [];
-  const stage2 = maxStages >= 3 ? candidatesAt(2) : [];
 
   // Single-stage solutions.
   for (const a of stage0) {
@@ -723,9 +726,16 @@ export async function findGearboxes(
     }
   }
 
-  // Three-stage solutions. The first two stages are enumerated and the third is
-  // resolved by binary search; only a bounded best-by-error set is kept so
-  // memory stays flat no matter how many combinations exist.
+  // Three-stage solutions are an automatic fallback: we only search them when no
+  // one- or two-stage gearbox can reach the target. This keeps normal searches
+  // fast (the third stage is never built) and means the user never has to ask
+  // for three stages — they appear exactly when they are the only option. The
+  // first two stages are enumerated and the third is resolved by binary search,
+  // keeping only a bounded best-by-error set so memory stays flat for high
+  // ratios.
+  let autoExpandedToThreeStage = false;
+  const stage2 =
+    maxStages >= 3 && solutions.length === 0 ? candidatesAt(2) : [];
   if (stage0.length > 0 && stage1.length > 0 && stage2.length > 0) {
     const { sorted, ratios, lowerBound } = sortedIndex(stage2);
     const min = ratios[0];
@@ -773,6 +783,7 @@ export async function findGearboxes(
     }
 
     for (const entry of kept) solutions.push(entry.solution);
+    autoExpandedToThreeStage = solutions.length > 0;
   }
 
   solutions.sort(
@@ -793,5 +804,6 @@ export async function findGearboxes(
   return Promise.resolve({
     count: solutions.length,
     solutions: solutions.slice(0, 50),
+    autoExpandedToThreeStage,
   });
 }

--- a/app/lib/math/ratioFinder.worker.ts
+++ b/app/lib/math/ratioFinder.worker.ts
@@ -6,7 +6,12 @@ import Pulley from '~/lib/models/Pulley';
 import type { RatioDict } from '~/lib/models/Ratio';
 import Ratio from '~/lib/models/Ratio';
 import Sprocket from '~/lib/models/Sprocket';
-import { type Bore, type Vendor, zBoreSchema } from '~/lib/types/common';
+import {
+  type Bore,
+  type StageFamily,
+  type Vendor,
+  zBoreSchema,
+} from '~/lib/types/common';
 import type { JSONGear } from '~/lib/types/gears';
 import type { JSONPlanetaryInstance } from '~/lib/types/planetary';
 import type { JSONPulley } from '~/lib/types/pulleys';
@@ -60,6 +65,15 @@ export interface FindGearboxesFilters {
   enableCustomPulleys: boolean;
   enableCustomSprockets: boolean;
   enablePlanetaries: boolean;
+
+  /**
+   * Per-stage transmission-family constraints, applied positionally. Index 0
+   * restricts the first stage, index 1 the second; the stage count itself is
+   * still discovered automatically. Each inner array lists the families allowed
+   * for that stage, and an absent or empty entry leaves that stage open to any
+   * family. When omitted entirely the finder behaves exactly as before.
+   */
+  stageConstraints?: StageFamily[][];
 }
 
 interface SkuInfo {
@@ -430,6 +444,21 @@ export async function findGearboxes(
   const withinErrorThreshold = (ratio: number, targetRatio: number) => {
     return Math.abs(ratio - targetRatio) <= targetReductionErrorThreshold;
   };
+
+  // Per-stage transmission-family filter applied positionally: stage index 0 is
+  // governed by stageConstraints[0], index 1 by stageConstraints[1]. The stage
+  // count is still discovered automatically (1- and 2-stage solutions are both
+  // enumerated), so a 1-stage solution only needs to satisfy the first stage's
+  // filter. An absent or empty entry leaves that stage open to any family, so
+  // the default (no constraints) preserves the original behavior exactly.
+  const stageConstraints = filters.stageConstraints ?? [];
+  const stageAllowsFamily = (stageIndex: number, family: StageFamily) => {
+    const allowed = stageConstraints[stageIndex];
+    return (
+      allowed === undefined || allowed.length === 0 || allowed.includes(family)
+    );
+  };
+
   for (const [tooth1, tooth2, ratio] of allValidStagesWithRatios) {
     if (tooth1 === tooth2) {
       continue;
@@ -722,12 +751,14 @@ export async function findGearboxes(
 
   for (const maybeSolution of maybeSolutions) {
     for (const [index, stage] of maybeSolution.stages.entries()) {
-      const maybe20DPGears = stageFrom20DPGears(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allGears,
-      );
+      const maybe20DPGears = stageAllowsFamily(index, 'Gear')
+        ? stageFrom20DPGears(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allGears,
+          )
+        : null;
       if (maybe20DPGears) {
         const [driving, driven] = maybe20DPGears;
 
@@ -735,12 +766,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((g) => skuInfoMap.get(g.sku!)!));
       }
 
-      const maybe32DPGears = stageFrom32DPGears(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allGears,
-      );
+      const maybe32DPGears = stageAllowsFamily(index, 'Gear')
+        ? stageFrom32DPGears(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allGears,
+          )
+        : null;
       if (maybe32DPGears) {
         const [driving, driven] = maybe32DPGears;
 
@@ -748,12 +781,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((g) => skuInfoMap.get(g.sku!)!));
       }
 
-      const maybeGT2Pulleys = stageFromGT2Pulleys(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allPulleys,
-      );
+      const maybeGT2Pulleys = stageAllowsFamily(index, 'Belt')
+        ? stageFromGT2Pulleys(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allPulleys,
+          )
+        : null;
       if (maybeGT2Pulleys) {
         const [driving, driven] = maybeGT2Pulleys;
 
@@ -761,12 +796,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((p) => skuInfoMap.get(p.sku!)!));
       }
 
-      const maybeHTDPulleys = stageFromHTDPulleys(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allPulleys,
-      );
+      const maybeHTDPulleys = stageAllowsFamily(index, 'Belt')
+        ? stageFromHTDPulleys(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allPulleys,
+          )
+        : null;
       if (maybeHTDPulleys) {
         const [driving, driven] = maybeHTDPulleys;
 
@@ -774,12 +811,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((p) => skuInfoMap.get(p.sku!)!));
       }
 
-      const maybe25ChainSprockets = stageFrom25ChainSprockets(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allSprockets,
-      );
+      const maybe25ChainSprockets = stageAllowsFamily(index, 'Chain')
+        ? stageFrom25ChainSprockets(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allSprockets,
+          )
+        : null;
       if (maybe25ChainSprockets) {
         const [driving, driven] = maybe25ChainSprockets;
 
@@ -787,12 +826,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((s) => skuInfoMap.get(s.sku!)!));
       }
 
-      const maybe35ChainSprockets = stageFrom35ChainSprockets(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allSprockets,
-      );
+      const maybe35ChainSprockets = stageAllowsFamily(index, 'Chain')
+        ? stageFrom35ChainSprockets(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allSprockets,
+          )
+        : null;
       if (maybe35ChainSprockets) {
         const [driving, driven] = maybe35ChainSprockets;
 
@@ -800,12 +841,14 @@ export async function findGearboxes(
         stage.to.skus.push(...driven.map((s) => skuInfoMap.get(s.sku!)!));
       }
 
-      const maybePlanetaries = stageFromPlanetaries(
-        [stage.from.teeth, stage.to.teeth],
-        index,
-        startingBore,
-        allPlanetaries,
-      );
+      const maybePlanetaries = stageAllowsFamily(index, 'Planetary')
+        ? stageFromPlanetaries(
+            [stage.from.teeth, stage.to.teeth],
+            index,
+            startingBore,
+            allPlanetaries,
+          )
+        : null;
       if (maybePlanetaries) {
         stage.from.skus.push(
           ...maybePlanetaries.map(

--- a/app/lib/math/ratioFinder.worker.ts
+++ b/app/lib/math/ratioFinder.worker.ts
@@ -99,203 +99,6 @@ export interface GearboxSolution {
   }[];
 }
 
-function stageFrom20DPGears(
-  stage: [number, number],
-  stageIndex: number,
-  startingBore: Bore,
-  gears: Gear[],
-): [Gear[], Gear[]] | null {
-  const [teeth1, teeth2] = stage;
-
-  const gear1 = gears.filter(
-    (g) =>
-      g.teeth === teeth1 &&
-      g.dp === 20 &&
-      (stageIndex === 0
-        ? g.bore === startingBore
-        : !MOTOR_BORES.includes(g.bore)),
-  );
-  const gear2 = gears.filter(
-    (g) => g.teeth === teeth2 && g.dp === 20 && !MOTOR_BORES.includes(g.bore),
-  );
-
-  if (gear1.length === 0 || gear2.length === 0) {
-    return null;
-  }
-
-  return [gear1, gear2];
-}
-
-function stageFrom32DPGears(
-  stage: [number, number],
-  stageIndex: number,
-  startingBore: Bore,
-  gears: Gear[],
-): [Gear[], Gear[]] | null {
-  const [teeth1, teeth2] = stage;
-
-  const gear1 = gears.filter(
-    (g) =>
-      g.teeth === teeth1 &&
-      g.dp === 32 &&
-      (stageIndex === 0
-        ? g.bore === startingBore
-        : !MOTOR_BORES.includes(g.bore)),
-  );
-  const gear2 = gears.filter(
-    (g) => g.teeth === teeth2 && g.dp === 32 && !MOTOR_BORES.includes(g.bore),
-  );
-
-  if (gear1.length === 0 || gear2.length === 0) {
-    return null;
-  }
-
-  return [gear1, gear2];
-}
-
-function stageFromGT2Pulleys(
-  stage: [number, number],
-  stageIndex: number,
-  startingBore: Bore,
-  pulleys: Pulley[],
-): [Pulley[], Pulley[]] | null {
-  const [teeth1, teeth2] = stage;
-
-  const pulley1 = pulleys.filter(
-    (p) =>
-      p.teeth === teeth1 &&
-      p.pitch.eq(new Measurement(3, 'mm')) &&
-      (stageIndex === 0
-        ? p.bore === startingBore
-        : !MOTOR_BORES.includes(p.bore)),
-  );
-  const pulley2 = pulleys.filter(
-    (p) =>
-      p.teeth === teeth2 &&
-      p.pitch.eq(new Measurement(3, 'mm')) &&
-      !MOTOR_BORES.includes(p.bore),
-  );
-
-  if (pulley1.length === 0 || pulley2.length === 0) {
-    return null;
-  }
-
-  return [pulley1, pulley2];
-}
-
-function stageFromHTDPulleys(
-  stage: [number, number],
-  stageIndex: number,
-  startingBore: Bore,
-  pulleys: Pulley[],
-): [Pulley[], Pulley[]] | null {
-  const [teeth1, teeth2] = stage;
-
-  const pulley1 = pulleys.filter(
-    (p) =>
-      p.teeth === teeth1 &&
-      p.pitch.eq(new Measurement(5, 'mm')) &&
-      (stageIndex === 0
-        ? p.bore === startingBore
-        : !MOTOR_BORES.includes(p.bore)),
-  );
-  const pulley2 = pulleys.filter(
-    (p) =>
-      p.teeth === teeth2 &&
-      p.pitch.eq(new Measurement(5, 'mm')) &&
-      !MOTOR_BORES.includes(p.bore),
-  );
-
-  if (pulley1.length === 0 || pulley2.length === 0) {
-    return null;
-  }
-
-  return [pulley1, pulley2];
-}
-
-function stageFrom25ChainSprockets(
-  stage: [number, number],
-  stageIndex: number,
-  startingBore: Bore,
-  sprockets: Sprocket[],
-): [Sprocket[], Sprocket[]] | null {
-  const [teeth1, teeth2] = stage;
-  const sprocket1 = sprockets.filter(
-    (s) =>
-      s.teeth === teeth1 &&
-      s.chainType === '#25' &&
-      (stageIndex === 0
-        ? s.bore === startingBore
-        : !MOTOR_BORES.includes(s.bore)),
-  );
-  const sprocket2 = sprockets.filter(
-    (s) =>
-      s.teeth === teeth2 &&
-      s.chainType === '#25' &&
-      !MOTOR_BORES.includes(s.bore),
-  );
-
-  if (sprocket1.length === 0 || sprocket2.length === 0) {
-    return null;
-  }
-
-  return [sprocket1, sprocket2];
-}
-
-function stageFrom35ChainSprockets(
-  stage: [number, number],
-  stageIndex: number,
-  startingBore: Bore,
-  sprockets: Sprocket[],
-): [Sprocket[], Sprocket[]] | null {
-  const [teeth1, teeth2] = stage;
-  const sprocket1 = sprockets.filter(
-    (s) =>
-      s.teeth === teeth1 &&
-      s.chainType === '#35' &&
-      (stageIndex === 0
-        ? s.bore === startingBore
-        : !MOTOR_BORES.includes(s.bore)),
-  );
-  const sprocket2 = sprockets.filter(
-    (s) =>
-      s.teeth === teeth2 &&
-      s.chainType === '#35' &&
-      !MOTOR_BORES.includes(s.bore),
-  );
-
-  if (sprocket1.length === 0 || sprocket2.length === 0) {
-    return null;
-  }
-
-  return [sprocket1, sprocket2];
-}
-
-function stageFromPlanetaries(
-  stage: [number, number],
-  stageIndex: number,
-  startingBore: Bore,
-  planetaries: JSONPlanetaryInstance[],
-): JSONPlanetaryInstance[] | null {
-  const [teeth1, teeth2] = stage;
-  if (teeth1 !== 1) {
-    return null;
-  }
-
-  const planetary = planetaries.filter(
-    (p) =>
-      (stageIndex === 0
-        ? p.inputBore === startingBore
-        : !MOTOR_BORES.includes(p.inputBore)) && p.ratio === teeth2 / teeth1,
-  );
-
-  if (planetary.length === 0) {
-    return null;
-  }
-
-  return planetary;
-}
-
 function generateCustomGears(
   minTeeth: number,
   maxTeeth: number,
@@ -363,12 +166,12 @@ export async function findGearboxes(
   targetReductionErrorThreshold: number,
   startingBore: Bore,
   filters: FindGearboxesFilters,
+  maxStages = 2,
 ): Promise<{
   count: number;
   solutions: GearboxSolution[];
 }> {
   const targetReduction = Ratio.fromDict(targetReduction_);
-  const maybeSolutions: GearboxSolution[] = [];
   const skuInfoMap = new Map<string, SkuInfo>();
 
   const vendorMap: Record<string, boolean> = {
@@ -458,42 +261,6 @@ export async function findGearboxes(
       allowed === undefined || allowed.length === 0 || allowed.includes(family)
     );
   };
-
-  for (const [tooth1, tooth2, ratio] of allValidStagesWithRatios) {
-    if (tooth1 === tooth2) {
-      continue;
-    }
-    if (withinErrorThreshold(ratio, targetReduction.asNumber())) {
-      maybeSolutions.push({
-        ratio: ratio,
-        stages: [
-          {
-            from: { teeth: tooth1, skus: [] },
-            to: { teeth: tooth2, skus: [] },
-          },
-        ],
-      });
-    }
-
-    for (const [tooth3, tooth4, ratio2] of allValidStagesWithRatios) {
-      const combinedRatio = ratio * ratio2;
-      if (withinErrorThreshold(combinedRatio, targetReduction.asNumber())) {
-        maybeSolutions.push({
-          ratio: combinedRatio,
-          stages: [
-            {
-              from: { teeth: tooth1, skus: [] },
-              to: { teeth: tooth2, skus: [] },
-            },
-            {
-              from: { teeth: tooth3, skus: [] },
-              to: { teeth: tooth4, skus: [] },
-            },
-          ],
-        });
-      }
-    }
-  }
 
   allPlanetaries.forEach((p) => {
     skuInfoMap.set(`${p.sku}-${p.inputBore}-${p.slices.join(':')}`, {
@@ -747,140 +514,265 @@ export async function findGearboxes(
           return true;
         }),
     );
+  // Teeth-indexed SKU buckets per transmission variant, split by whether the
+  // part can sit on the starting (motor) shaft or any non-motor shaft. Matching
+  // a stage then becomes O(1) lookups instead of scanning the full parts list
+  // for every candidate, which dominated runtime on large searches.
+  const skuSorter = (a: SkuInfo, b: SkuInfo) =>
+    a.family.localeCompare(b.family) ||
+    a.vendor.localeCompare(b.vendor) ||
+    a.pitch.localeCompare(b.pitch) ||
+    a.bore.localeCompare(b.bore) ||
+    a.sku.localeCompare(b.sku);
+
+  interface VariantBucket {
+    first: Map<number, SkuInfo[]>;
+    nonMotor: Map<number, SkuInfo[]>;
+  }
+  const newBucket = (): VariantBucket => ({
+    first: new Map(),
+    nonMotor: new Map(),
+  });
+  const pushInto = (
+    map: Map<number, SkuInfo[]>,
+    teeth: number,
+    sku: SkuInfo,
+  ) => {
+    const arr = map.get(teeth);
+    if (arr) arr.push(sku);
+    else map.set(teeth, [sku]);
+  };
+  const addToBucket = (
+    bucket: VariantBucket,
+    teeth: number,
+    bore: Bore,
+    sku: SkuInfo,
+  ) => {
+    if (bore === startingBore) pushInto(bucket.first, teeth, sku);
+    if (!MOTOR_BORES.includes(bore)) pushInto(bucket.nonMotor, teeth, sku);
+  };
+
+  const gear20 = newBucket();
+  const gear32 = newBucket();
+  const gt2 = newBucket();
+  const htd = newBucket();
+  const chain25 = newBucket();
+  const chain35 = newBucket();
+  for (const g of allGears) {
+    const sku = skuInfoMap.get(g.sku ?? '');
+    if (!sku) continue;
+    // Only 20DP and 32DP gears mesh in the families the finder supports; any
+    // other diametral pitch is ignored (matching the original matchers).
+    if (g.dp === 20) addToBucket(gear20, g.teeth, g.bore, sku);
+    else if (g.dp === 32) addToBucket(gear32, g.teeth, g.bore, sku);
+  }
+  const mm3 = new Measurement(3, 'mm');
+  const mm5 = new Measurement(5, 'mm');
+  for (const p of allPulleys) {
+    const sku = skuInfoMap.get(p.sku ?? '');
+    if (!sku) continue;
+    if (p.pitch.eq(mm3)) addToBucket(gt2, p.teeth, p.bore, sku);
+    else if (p.pitch.eq(mm5)) addToBucket(htd, p.teeth, p.bore, sku);
+  }
+  for (const s of allSprockets) {
+    const sku = skuInfoMap.get(s.sku ?? '');
+    if (!sku) continue;
+    if (s.chainType === '#25') addToBucket(chain25, s.teeth, s.bore, sku);
+    else if (s.chainType === '#35') addToBucket(chain35, s.teeth, s.bore, sku);
+  }
+
+  const planetaryFirst = new Map<number, { from: SkuInfo; to: SkuInfo }[]>();
+  const planetaryInner = new Map<number, { from: SkuInfo; to: SkuInfo }[]>();
+  const pushPlanet = (
+    map: Map<number, { from: SkuInfo; to: SkuInfo }[]>,
+    ratio: number,
+    pair: { from: SkuInfo; to: SkuInfo },
+  ) => {
+    const arr = map.get(ratio);
+    if (arr) arr.push(pair);
+    else map.set(ratio, [pair]);
+  };
+  for (const p of allPlanetaries) {
+    const slices = p.slices.join(':');
+    const from = skuInfoMap.get(`${p.sku}-${p.inputBore}-${slices}`);
+    const to = skuInfoMap.get(`${p.sku}-${p.outputBore}-${slices}`);
+    if (!from || !to) continue;
+    if (p.inputBore === startingBore && !MOTOR_BORES.includes(p.outputBore))
+      pushPlanet(planetaryFirst, p.ratio, { from, to });
+    if (
+      !MOTOR_BORES.includes(p.inputBore) &&
+      !MOTOR_BORES.includes(p.outputBore)
+    )
+      pushPlanet(planetaryInner, p.ratio, { from, to });
+  }
+
+  const toothedVariants: [VariantBucket, StageFamily][] = [
+    [gear20, 'Gear'],
+    [gear32, 'Gear'],
+    [gt2, 'Belt'],
+    [htd, 'Belt'],
+    [chain25, 'Chain'],
+    [chain35, 'Chain'],
+  ];
+
+  // Build a fully-matched stage for a [from, to] tooth pair at a given stage
+  // position (0 == on the motor shaft), or null when no real parts realize it.
+  const matchStageAt = (
+    fromTeeth: number,
+    toTeeth: number,
+    position: number,
+  ): GearboxSolution['stages'][number] | null => {
+    const isFirst = position === 0;
+    const fromSkus: SkuInfo[] = [];
+    const toSkus: SkuInfo[] = [];
+    for (const [bucket, family] of toothedVariants) {
+      if (!stageAllowsFamily(position, family)) continue;
+      const driving = (isFirst ? bucket.first : bucket.nonMotor).get(fromTeeth);
+      const driven = bucket.nonMotor.get(toTeeth);
+      if (driving && driven) {
+        fromSkus.push(...driving);
+        toSkus.push(...driven);
+      }
+    }
+    if (stageAllowsFamily(position, 'Planetary') && fromTeeth === 1) {
+      const pairs = (isFirst ? planetaryFirst : planetaryInner).get(toTeeth);
+      if (pairs)
+        for (const pair of pairs) {
+          fromSkus.push(pair.from);
+          toSkus.push(pair.to);
+        }
+    }
+    if (fromSkus.length === 0 || toSkus.length === 0) return null;
+    fromSkus.sort(skuSorter);
+    toSkus.sort(skuSorter);
+    return {
+      from: { teeth: fromTeeth, skus: fromSkus },
+      to: { teeth: toTeeth, skus: toSkus },
+    };
+  };
+
+  // Build each stage position's buildable candidates once (each already carries
+  // its matched SKUs), then enumerate combinations over only those candidates.
+  // Iterating buildable stages instead of the full tooth grid is what keeps
+  // every stage count fast — most tooth pairs have no real parts.
+  interface Candidate {
+    ratio: number;
+    stage: GearboxSolution['stages'][number];
+  }
+  const candidatesAt = (position: number): Candidate[] => {
+    const out: Candidate[] = [];
+    for (const [t1, t2, ratio] of allValidStagesWithRatios) {
+      const stage = matchStageAt(t1, t2, position);
+      if (stage) out.push({ ratio, stage });
+    }
+    return out;
+  };
+
+  // A sorted-ratio view of a candidate list, for binary-searching the narrow
+  // window of last-stage ratios that bring a combination onto the target.
+  const sortedIndex = (candidates: Candidate[]) => {
+    const sorted = [...candidates].sort((a, b) => a.ratio - b.ratio);
+    const ratios = sorted.map((c) => c.ratio);
+    const lowerBound = (value: number) => {
+      let lo = 0;
+      let hi = ratios.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (ratios[mid] < value) lo = mid + 1;
+        else hi = mid;
+      }
+      return lo;
+    };
+    return { sorted, ratios, lowerBound };
+  };
+
+  const target = targetReduction.asNumber();
   const solutions: GearboxSolution[] = [];
 
-  for (const maybeSolution of maybeSolutions) {
-    for (const [index, stage] of maybeSolution.stages.entries()) {
-      const maybe20DPGears = stageAllowsFamily(index, 'Gear')
-        ? stageFrom20DPGears(
-            [stage.from.teeth, stage.to.teeth],
-            index,
-            startingBore,
-            allGears,
-          )
-        : null;
-      if (maybe20DPGears) {
-        const [driving, driven] = maybe20DPGears;
+  const stage0 = candidatesAt(0);
+  const stage1 = maxStages >= 2 ? candidatesAt(1) : [];
+  const stage2 = maxStages >= 3 ? candidatesAt(2) : [];
 
-        stage.from.skus.push(...driving.map((g) => skuInfoMap.get(g.sku!)!));
-        stage.to.skus.push(...driven.map((g) => skuInfoMap.get(g.sku!)!));
-      }
-
-      const maybe32DPGears = stageAllowsFamily(index, 'Gear')
-        ? stageFrom32DPGears(
-            [stage.from.teeth, stage.to.teeth],
-            index,
-            startingBore,
-            allGears,
-          )
-        : null;
-      if (maybe32DPGears) {
-        const [driving, driven] = maybe32DPGears;
-
-        stage.from.skus.push(...driving.map((g) => skuInfoMap.get(g.sku!)!));
-        stage.to.skus.push(...driven.map((g) => skuInfoMap.get(g.sku!)!));
-      }
-
-      const maybeGT2Pulleys = stageAllowsFamily(index, 'Belt')
-        ? stageFromGT2Pulleys(
-            [stage.from.teeth, stage.to.teeth],
-            index,
-            startingBore,
-            allPulleys,
-          )
-        : null;
-      if (maybeGT2Pulleys) {
-        const [driving, driven] = maybeGT2Pulleys;
-
-        stage.from.skus.push(...driving.map((p) => skuInfoMap.get(p.sku!)!));
-        stage.to.skus.push(...driven.map((p) => skuInfoMap.get(p.sku!)!));
-      }
-
-      const maybeHTDPulleys = stageAllowsFamily(index, 'Belt')
-        ? stageFromHTDPulleys(
-            [stage.from.teeth, stage.to.teeth],
-            index,
-            startingBore,
-            allPulleys,
-          )
-        : null;
-      if (maybeHTDPulleys) {
-        const [driving, driven] = maybeHTDPulleys;
-
-        stage.from.skus.push(...driving.map((p) => skuInfoMap.get(p.sku!)!));
-        stage.to.skus.push(...driven.map((p) => skuInfoMap.get(p.sku!)!));
-      }
-
-      const maybe25ChainSprockets = stageAllowsFamily(index, 'Chain')
-        ? stageFrom25ChainSprockets(
-            [stage.from.teeth, stage.to.teeth],
-            index,
-            startingBore,
-            allSprockets,
-          )
-        : null;
-      if (maybe25ChainSprockets) {
-        const [driving, driven] = maybe25ChainSprockets;
-
-        stage.from.skus.push(...driving.map((s) => skuInfoMap.get(s.sku!)!));
-        stage.to.skus.push(...driven.map((s) => skuInfoMap.get(s.sku!)!));
-      }
-
-      const maybe35ChainSprockets = stageAllowsFamily(index, 'Chain')
-        ? stageFrom35ChainSprockets(
-            [stage.from.teeth, stage.to.teeth],
-            index,
-            startingBore,
-            allSprockets,
-          )
-        : null;
-      if (maybe35ChainSprockets) {
-        const [driving, driven] = maybe35ChainSprockets;
-
-        stage.from.skus.push(...driving.map((s) => skuInfoMap.get(s.sku!)!));
-        stage.to.skus.push(...driven.map((s) => skuInfoMap.get(s.sku!)!));
-      }
-
-      const maybePlanetaries = stageAllowsFamily(index, 'Planetary')
-        ? stageFromPlanetaries(
-            [stage.from.teeth, stage.to.teeth],
-            index,
-            startingBore,
-            allPlanetaries,
-          )
-        : null;
-      if (maybePlanetaries) {
-        stage.from.skus.push(
-          ...maybePlanetaries.map(
-            (p) =>
-              skuInfoMap.get(`${p.sku}-${p.inputBore}-${p.slices.join(':')}`)!,
-          ),
-        );
-        stage.to.skus.push(
-          ...maybePlanetaries.map(
-            (p) =>
-              skuInfoMap.get(`${p.sku}-${p.outputBore}-${p.slices.join(':')}`)!,
-          ),
-        );
-      }
-
-      const sorter = (a: SkuInfo, b: SkuInfo) =>
-        a.family.localeCompare(b.family) ||
-        a.vendor.localeCompare(b.vendor) ||
-        a.pitch.localeCompare(b.pitch) ||
-        a.bore.localeCompare(b.bore) ||
-        a.sku.localeCompare(b.sku);
-      stage.from.skus.sort(sorter);
-      stage.to.skus.sort(sorter);
+  // Single-stage solutions.
+  for (const a of stage0) {
+    if (withinErrorThreshold(a.ratio, target)) {
+      solutions.push({ ratio: a.ratio, stages: [a.stage] });
     }
+  }
 
-    if (
-      maybeSolution.stages.every(
-        (stage) => stage.from.skus.length > 0 && stage.to.skus.length > 0,
+  // Two-stage solutions. The full set is collected; it is naturally bounded.
+  if (stage0.length > 0 && stage1.length > 0) {
+    const { sorted, ratios, lowerBound } = sortedIndex(stage1);
+    const min = ratios[0];
+    const max = ratios[ratios.length - 1];
+    for (const a of stage0) {
+      const needLo = (target - targetReductionErrorThreshold) / a.ratio;
+      const needHi = (target + targetReductionErrorThreshold) / a.ratio;
+      if (needHi < min || needLo > max) continue;
+      for (
+        let k = lowerBound(needLo - 1e-9);
+        k < sorted.length && ratios[k] <= needHi + 1e-9;
+        k++
+      ) {
+        const b = sorted[k];
+        const ratio = a.ratio * b.ratio;
+        if (withinErrorThreshold(ratio, target)) {
+          solutions.push({ ratio, stages: [a.stage, b.stage] });
+        }
+      }
+    }
+  }
+
+  // Three-stage solutions. The first two stages are enumerated and the third is
+  // resolved by binary search; only a bounded best-by-error set is kept so
+  // memory stays flat no matter how many combinations exist.
+  if (stage0.length > 0 && stage1.length > 0 && stage2.length > 0) {
+    const { sorted, ratios, lowerBound } = sortedIndex(stage2);
+    const min = ratios[0];
+    const max = ratios[ratios.length - 1];
+    const THREE_STAGE_CAP = 500;
+    const kept: { error: number; solution: GearboxSolution }[] = [];
+    const consider = (solution: GearboxSolution, error: number) => {
+      if (
+        kept.length >= THREE_STAGE_CAP &&
+        error >= kept[kept.length - 1].error
       )
-    ) {
-      solutions.push(maybeSolution);
+        return;
+      let lo = 0;
+      let hi = kept.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (kept[mid].error <= error) lo = mid + 1;
+        else hi = mid;
+      }
+      kept.splice(lo, 0, { error, solution });
+      if (kept.length > THREE_STAGE_CAP) kept.pop();
+    };
+
+    for (const a of stage0) {
+      for (const b of stage1) {
+        const ratio12 = a.ratio * b.ratio;
+        const needLo = (target - targetReductionErrorThreshold) / ratio12;
+        const needHi = (target + targetReductionErrorThreshold) / ratio12;
+        if (needHi < min || needLo > max) continue;
+        for (
+          let k = lowerBound(needLo - 1e-9);
+          k < sorted.length && ratios[k] <= needHi + 1e-9;
+          k++
+        ) {
+          const c = sorted[k];
+          const ratio = ratio12 * c.ratio;
+          if (withinErrorThreshold(ratio, target)) {
+            consider(
+              { ratio, stages: [a.stage, b.stage, c.stage] },
+              Math.abs(ratio - target),
+            );
+          }
+        }
+      }
     }
+
+    for (const entry of kept) solutions.push(entry.solution);
   }
 
   solutions.sort(

--- a/app/lib/types/common.ts
+++ b/app/lib/types/common.ts
@@ -36,6 +36,15 @@ export const VENDOR_NAMES = [
 export type Vendor = (typeof VENDOR_NAMES)[number];
 export const zVendorSchema = z.enum(VENDOR_NAMES);
 
+/**
+ * User-facing power-transmission families selectable per ratio-finder stage.
+ * These map onto the internal {@link SkuInfo} families as follows:
+ *   Gear -> 'Gear', Belt -> 'Pulley', Chain -> 'Sprocket', Planetary -> 'Planetary'.
+ */
+export const STAGE_FAMILIES = ['Gear', 'Belt', 'Chain', 'Planetary'] as const;
+export const zStageFamilySchema = z.enum(STAGE_FAMILIES);
+export type StageFamily = z.infer<typeof zStageFamilySchema>;
+
 export type StateHook<T> = [T, Dispatch<SetStateAction<T>>];
 
 export type HasStateHook<T> = {

--- a/app/lib/types/queryParams.ts
+++ b/app/lib/types/queryParams.ts
@@ -4,11 +4,13 @@ import {
   parseAsFloat,
   parseAsString,
 } from 'nuqs';
+import * as z from 'zod';
 
 import Measurement from '~/lib/models/Measurement';
 import Motor from '~/lib/models/Motor';
 import Ratio, { RatioType } from '~/lib/models/Ratio';
-import type { Bore } from '~/lib/types/common';
+import type { Bore, StageFamily } from '~/lib/types/common';
+import { zStageFamilySchema } from '~/lib/types/common';
 
 export const StringParam = parseAsString;
 
@@ -81,6 +83,28 @@ export const RatioPairListParam = createParser<RatioPair[]>({
         return parsed;
       }
       return null;
+    } catch {
+      return null;
+    }
+  },
+  serialize(value) {
+    return JSON.stringify(value);
+  },
+});
+
+/**
+ * Per-stage transmission-family constraints for the ratio finder, applied
+ * positionally (index 0 = stage 1, index 1 = stage 2). Each inner array lists
+ * the families allowed for that stage; an empty inner array means "any family".
+ * The stage count is not encoded here -- it is still discovered automatically.
+ */
+const zStageConstraintsSchema = z.array(z.array(zStageFamilySchema));
+
+export const StageConstraintListParam = createParser<StageFamily[][]>({
+  parse(value) {
+    try {
+      const result = zStageConstraintsSchema.safeParse(JSON.parse(value));
+      return result.success ? result.data : null;
     } catch {
       return null;
     }

--- a/app/routes/ratio-finder.tsx
+++ b/app/routes/ratio-finder.tsx
@@ -594,7 +594,7 @@ export default function RatioFinder() {
               className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
               data-testid="three-stage-notice"
             >
-              No one- or two-stage gearbox reaches this ratio with the current
+              No one or two-stage gearbox reaches this ratio with the current
               filters — showing three-stage options.
             </div>
           )}

--- a/app/routes/ratio-finder.tsx
+++ b/app/routes/ratio-finder.tsx
@@ -68,7 +68,6 @@ const DEFAULT_PARAMS = {
   startingBore: BoreParam.withDefault('SplineXS' as Bore),
   // Empty array == "Auto" (unconstrained stage count and per-stage type).
   stageConstraints: StageConstraintListParam.withDefault([]),
-  enable3Stage: BooleanParam.withDefault(false),
 };
 
 const worker = new ComlinkWorker<typeof RatioFinderWorker>(
@@ -150,11 +149,12 @@ export default function RatioFinder() {
   );
   const [startingBore, setStartingBore] = useState(queryParams.startingBore);
 
-  // Per-stage transmission-type filters. These are positional: the Stage 1
-  // filter applies to every solution's first stage, the Stage 2 filter only to
-  // 2-stage solutions, the Stage 3 filter only to 3-stage solutions. Each
-  // defaults to all families, so the finder behaves exactly as before until the
-  // user narrows a stage. A stage with no families selected is treated as "any".
+  // Per-stage transmission-type filters, applied positionally: the Stage 1
+  // filter governs every solution's first stage, Stage 2 the second, Stage 3 a
+  // third stage. The finder searches one or two stages and only falls back to
+  // three when nothing else reaches the target, so the Stage 3 filter only
+  // matters in that case. Each defaults to all families; an empty stage means
+  // "any type".
   const initialStageConstraints = queryParams.stageConstraints;
   const [stage1Families, setStage1Families] = useState<StageFamily[]>(
     initialStageConstraints[0] ?? [...STAGE_FAMILIES],
@@ -165,16 +165,10 @@ export default function RatioFinder() {
   const [stage3Families, setStage3Families] = useState<StageFamily[]>(
     initialStageConstraints[2] ?? [...STAGE_FAMILIES],
   );
-  // Three-stage search is opt-in (it is slower and most gearboxes need ≤2).
-  const [enable3Stage, setEnable3Stage] = useState(queryParams.enable3Stage);
-  const maxStages = enable3Stage ? 3 : 2;
 
   const stageConstraints = useMemo<StageFamily[][]>(
-    () =>
-      enable3Stage
-        ? [stage1Families, stage2Families, stage3Families]
-        : [stage1Families, stage2Families],
-    [enable3Stage, stage1Families, stage2Families, stage3Families],
+    () => [stage1Families, stage2Families, stage3Families],
+    [stage1Families, stage2Families, stage3Families],
   );
 
   const [solutions, setSolutions] = useState<
@@ -182,6 +176,9 @@ export default function RatioFinder() {
   >([]);
   const [count, setCount] = useState(0);
   const [loading, setLoading] = useState(false);
+  // True when the only gearboxes found needed a third stage.
+  const [autoExpandedToThreeStage, setAutoExpandedToThreeStage] =
+    useState(false);
 
   const filters: RatioFinderWorker.FindGearboxesFilters = useMemo(
     () => ({
@@ -269,7 +266,6 @@ export default function RatioFinder() {
         targetReductionErrorThreshold,
         startingBore,
         filters,
-        maxStages,
       )
       .then((results) => {
         if (cancelled) {
@@ -277,6 +273,7 @@ export default function RatioFinder() {
         }
         setCount(results.count);
         setSolutions(results.solutions);
+        setAutoExpandedToThreeStage(results.autoExpandedToThreeStage);
         setLoading(false);
       })
       .catch((error) => {
@@ -286,19 +283,14 @@ export default function RatioFinder() {
         console.error(error);
         setSolutions([]);
         setCount(0);
+        setAutoExpandedToThreeStage(false);
         setLoading(false);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [
-    targetReduction,
-    targetReductionErrorThreshold,
-    startingBore,
-    filters,
-    maxStages,
-  ]);
+  }, [targetReduction, targetReductionErrorThreshold, startingBore, filters]);
 
   const serializedState = useSerializedState(DEFAULT_PARAMS, {
     minGearTeeth,
@@ -335,7 +327,6 @@ export default function RatioFinder() {
     enableCustomSprockets,
     startingBore,
     stageConstraints,
-    enable3Stage,
   });
 
   return (
@@ -356,6 +347,7 @@ export default function RatioFinder() {
                   stateHook={[targetReduction, setTargetReduction]}
                   debounceDelay={300}
                   labelAbove
+                  testId="reduction-magnitude"
                 />
                 <BoreInput
                   stateHook={[startingBore, setStartingBore]}
@@ -564,15 +556,11 @@ export default function RatioFinder() {
                 Transmission Type Per Stage
               </h2>
               <p className="text-xs text-muted-foreground">
-                Restrict which power transmission types each stage may use. Each
-                stage's filter only applies to solutions that actually have that
-                stage.
+                Restrict which power transmission types each stage may use. The
+                finder searches one or two stages and only adds a third stage
+                when nothing else reaches the target, so the Stage 3 filter
+                applies only in that case.
               </p>
-              <CheckboxBooleanInput
-                stateHook={[enable3Stage, setEnable3Stage]}
-                label="Search 3-stage gearboxes (slower)"
-                testId="enable-3-stage"
-              />
               <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
                 <StageFamilySelect
                   families={stage1Families}
@@ -586,14 +574,12 @@ export default function RatioFinder() {
                   label="Stage 2"
                   testId="stage-2-families"
                 />
-                {enable3Stage && (
-                  <StageFamilySelect
-                    families={stage3Families}
-                    setFamilies={setStage3Families}
-                    label="Stage 3"
-                    testId="stage-3-families"
-                  />
-                )}
+                <StageFamilySelect
+                  families={stage3Families}
+                  setFamilies={setStage3Families}
+                  label="Stage 3"
+                  testId="stage-3-families"
+                />
               </div>
             </div>
           </section>
@@ -603,6 +589,15 @@ export default function RatioFinder() {
           <Divider>
             {loading ? <Spinner /> : <>{count} Solutions Found</>}
           </Divider>
+          {autoExpandedToThreeStage && (
+            <div
+              className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
+              data-testid="three-stage-notice"
+            >
+              No one- or two-stage gearbox reaches this ratio with the current
+              filters — showing three-stage options.
+            </div>
+          )}
           {solutions.length === 0 ? (
             <div className="text-muted-foreground">No solutions found</div>
           ) : (

--- a/app/routes/ratio-finder.tsx
+++ b/app/routes/ratio-finder.tsx
@@ -68,6 +68,7 @@ const DEFAULT_PARAMS = {
   startingBore: BoreParam.withDefault('SplineXS' as Bore),
   // Empty array == "Auto" (unconstrained stage count and per-stage type).
   stageConstraints: StageConstraintListParam.withDefault([]),
+  enable3Stage: BooleanParam.withDefault(false),
 };
 
 const worker = new ComlinkWorker<typeof RatioFinderWorker>(
@@ -151,9 +152,9 @@ export default function RatioFinder() {
 
   // Per-stage transmission-type filters. These are positional: the Stage 1
   // filter applies to every solution's first stage, the Stage 2 filter only to
-  // 2-stage solutions. Each defaults to all families, so the finder behaves
-  // exactly as before until the user narrows a stage. A stage with no families
-  // selected is treated as "any type".
+  // 2-stage solutions, the Stage 3 filter only to 3-stage solutions. Each
+  // defaults to all families, so the finder behaves exactly as before until the
+  // user narrows a stage. A stage with no families selected is treated as "any".
   const initialStageConstraints = queryParams.stageConstraints;
   const [stage1Families, setStage1Families] = useState<StageFamily[]>(
     initialStageConstraints[0] ?? [...STAGE_FAMILIES],
@@ -161,10 +162,19 @@ export default function RatioFinder() {
   const [stage2Families, setStage2Families] = useState<StageFamily[]>(
     initialStageConstraints[1] ?? [...STAGE_FAMILIES],
   );
+  const [stage3Families, setStage3Families] = useState<StageFamily[]>(
+    initialStageConstraints[2] ?? [...STAGE_FAMILIES],
+  );
+  // Three-stage search is opt-in (it is slower and most gearboxes need ≤2).
+  const [enable3Stage, setEnable3Stage] = useState(queryParams.enable3Stage);
+  const maxStages = enable3Stage ? 3 : 2;
 
   const stageConstraints = useMemo<StageFamily[][]>(
-    () => [stage1Families, stage2Families],
-    [stage1Families, stage2Families],
+    () =>
+      enable3Stage
+        ? [stage1Families, stage2Families, stage3Families]
+        : [stage1Families, stage2Families],
+    [enable3Stage, stage1Families, stage2Families, stage3Families],
   );
 
   const [solutions, setSolutions] = useState<
@@ -259,6 +269,7 @@ export default function RatioFinder() {
         targetReductionErrorThreshold,
         startingBore,
         filters,
+        maxStages,
       )
       .then((results) => {
         if (cancelled) {
@@ -281,7 +292,13 @@ export default function RatioFinder() {
     return () => {
       cancelled = true;
     };
-  }, [targetReduction, targetReductionErrorThreshold, startingBore, filters]);
+  }, [
+    targetReduction,
+    targetReductionErrorThreshold,
+    startingBore,
+    filters,
+    maxStages,
+  ]);
 
   const serializedState = useSerializedState(DEFAULT_PARAMS, {
     minGearTeeth,
@@ -318,6 +335,7 @@ export default function RatioFinder() {
     enableCustomSprockets,
     startingBore,
     stageConstraints,
+    enable3Stage,
   });
 
   return (
@@ -546,10 +564,16 @@ export default function RatioFinder() {
                 Transmission Type Per Stage
               </h2>
               <p className="text-xs text-muted-foreground">
-                Restrict which power transmission types each stage may use. The
-                Stage 2 filter only affects two-stage solutions.
+                Restrict which power transmission types each stage may use. Each
+                stage's filter only applies to solutions that actually have that
+                stage.
               </p>
-              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <CheckboxBooleanInput
+                stateHook={[enable3Stage, setEnable3Stage]}
+                label="Search 3-stage gearboxes (slower)"
+                testId="enable-3-stage"
+              />
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
                 <StageFamilySelect
                   families={stage1Families}
                   setFamilies={setStage1Families}
@@ -562,6 +586,14 @@ export default function RatioFinder() {
                   label="Stage 2"
                   testId="stage-2-families"
                 />
+                {enable3Stage && (
+                  <StageFamilySelect
+                    families={stage3Families}
+                    setFamilies={setStage3Families}
+                    label="Stage 3"
+                    testId="stage-3-families"
+                  />
+                )}
               </div>
             </div>
           </section>

--- a/app/routes/ratio-finder.tsx
+++ b/app/routes/ratio-finder.tsx
@@ -1,3 +1,4 @@
+import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 
@@ -8,16 +9,20 @@ import BoreInput from '~/components/recalc/io/bore';
 import CheckboxBooleanInput from '~/components/recalc/io/checkboxBoolean';
 import NumberInput from '~/components/recalc/io/number';
 import { RatioInput } from '~/components/recalc/io/ratio';
+import { Checkbox } from '~/components/ui/checkbox';
+import { Label } from '~/components/ui/label';
 import { Spinner } from '~/components/ui/spinner';
 import { useQueryParams, useSerializedState } from '~/lib/hooks';
 import type * as RatioFinderWorker from '~/lib/math/ratioFinder.worker';
 import Ratio, { RatioType } from '~/lib/models/Ratio';
-import type { Bore } from '~/lib/types/common';
+import type { Bore, StageFamily } from '~/lib/types/common';
+import { STAGE_FAMILIES } from '~/lib/types/common';
 import {
   BooleanParam,
   BoreParam,
   NumberParam,
   RatioParam,
+  StageConstraintListParam,
 } from '~/lib/types/queryParams';
 
 export function meta() {
@@ -61,6 +66,8 @@ const DEFAULT_PARAMS = {
   enableCustomPulleys: BooleanParam.withDefault(false),
   enableCustomSprockets: BooleanParam.withDefault(false),
   startingBore: BoreParam.withDefault('SplineXS' as Bore),
+  // Empty array == "Auto" (unconstrained stage count and per-stage type).
+  stageConstraints: StageConstraintListParam.withDefault([]),
 };
 
 const worker = new ComlinkWorker<typeof RatioFinderWorker>(
@@ -142,6 +149,24 @@ export default function RatioFinder() {
   );
   const [startingBore, setStartingBore] = useState(queryParams.startingBore);
 
+  // Per-stage transmission-type filters. These are positional: the Stage 1
+  // filter applies to every solution's first stage, the Stage 2 filter only to
+  // 2-stage solutions. Each defaults to all families, so the finder behaves
+  // exactly as before until the user narrows a stage. A stage with no families
+  // selected is treated as "any type".
+  const initialStageConstraints = queryParams.stageConstraints;
+  const [stage1Families, setStage1Families] = useState<StageFamily[]>(
+    initialStageConstraints[0] ?? [...STAGE_FAMILIES],
+  );
+  const [stage2Families, setStage2Families] = useState<StageFamily[]>(
+    initialStageConstraints[1] ?? [...STAGE_FAMILIES],
+  );
+
+  const stageConstraints = useMemo<StageFamily[][]>(
+    () => [stage1Families, stage2Families],
+    [stage1Families, stage2Families],
+  );
+
   const [solutions, setSolutions] = useState<
     RatioFinderWorker.GearboxSolution[]
   >([]);
@@ -180,6 +205,7 @@ export default function RatioFinder() {
       enableCustomGears,
       enableCustomPulleys,
       enableCustomSprockets,
+      stageConstraints,
     }),
     [
       minGearTeeth,
@@ -212,10 +238,17 @@ export default function RatioFinder() {
       enableCustomGears,
       enableCustomPulleys,
       enableCustomSprockets,
+      stageConstraints,
     ],
   );
 
   useEffect(() => {
+    // findGearboxes is async (it awaits dynamic data imports), so successive
+    // calls interleave inside the worker and may resolve out of order. Ignore
+    // any response that arrives after the inputs have changed so a slower,
+    // stale request can never overwrite the latest results.
+    let cancelled = false;
+
     setCount(0);
     setSolutions([]);
     setLoading(true);
@@ -228,16 +261,26 @@ export default function RatioFinder() {
         filters,
       )
       .then((results) => {
+        if (cancelled) {
+          return;
+        }
         setCount(results.count);
         setSolutions(results.solutions);
         setLoading(false);
       })
       .catch((error) => {
+        if (cancelled) {
+          return;
+        }
         console.error(error);
         setSolutions([]);
         setCount(0);
         setLoading(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [targetReduction, targetReductionErrorThreshold, startingBore, filters]);
 
   const serializedState = useSerializedState(DEFAULT_PARAMS, {
@@ -274,6 +317,7 @@ export default function RatioFinder() {
     enableCustomPulleys,
     enableCustomSprockets,
     startingBore,
+    stageConstraints,
   });
 
   return (
@@ -495,6 +539,31 @@ export default function RatioFinder() {
                 </div>
               </div>
             </div>
+            <div className="border-t" />
+
+            <div className="flex flex-col gap-3 p-4">
+              <h2 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                Transmission Type Per Stage
+              </h2>
+              <p className="text-xs text-muted-foreground">
+                Restrict which power transmission types each stage may use. The
+                Stage 2 filter only affects two-stage solutions.
+              </p>
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                <StageFamilySelect
+                  families={stage1Families}
+                  setFamilies={setStage1Families}
+                  label="Stage 1"
+                  testId="stage-1-families"
+                />
+                <StageFamilySelect
+                  families={stage2Families}
+                  setFamilies={setStage2Families}
+                  label="Stage 2"
+                  testId="stage-2-families"
+                />
+              </div>
+            </div>
           </section>
         </div>
 
@@ -511,6 +580,59 @@ export default function RatioFinder() {
       </div>
     </div>
   );
+}
+
+function StageFamilySelect({
+  families,
+  setFamilies,
+  label,
+  testId,
+}: {
+  families: StageFamily[];
+  setFamilies: Dispatch<SetStateAction<StageFamily[]>>;
+  label: string;
+  testId?: string;
+}) {
+  // Use a functional update so rapid successive toggles each compose on the
+  // latest selection rather than a value captured at render time.
+  const toggle = (family: StageFamily, checked: boolean) => {
+    setFamilies((prev) =>
+      checked ? [...prev, family] : prev.filter((f) => f !== family),
+    );
+  };
+
+  return (
+    <div className="rounded-lg border bg-card p-3" data-testid={testId}>
+      <h3 className="mb-2 text-center text-sm font-semibold text-muted-foreground">
+        {label}
+      </h3>
+      <div className="flex flex-col gap-2">
+        {STAGE_FAMILIES.map((family) => (
+          <div key={family} className="flex flex-row items-center gap-2">
+            <Checkbox
+              aria-label={`${label} ${family}`}
+              checked={families.includes(family)}
+              onCheckedChange={(checked) => toggle(family, checked === true)}
+            />
+            <Label>{family}</Label>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Human-facing transmission family for a matched SKU. */
+function skuFamilyLabel(
+  family: 'Gear' | 'Pulley' | 'Sprocket' | 'Planetary',
+): string {
+  if (family === 'Pulley') {
+    return 'Belt';
+  }
+  if (family === 'Sprocket') {
+    return 'Chain';
+  }
+  return family;
 }
 
 export function GearboxList({
@@ -538,7 +660,7 @@ export function GearboxList({
     return pitch;
   };
   return (
-    <div className="w-full">
+    <div className="w-full" data-testid="gearbox-list">
       <div className="overflow-hidden rounded-lg border bg-card">
         <div className="overflow-x-auto">
           <table className="w-full">
@@ -581,61 +703,81 @@ export function GearboxList({
                   </td>
                   <td className="px-3 py-3">
                     <div className="space-y-2">
-                      {gearbox.stages.map((stage, stageIndex) => (
-                        <div key={stageIndex} className="text-xs">
-                          <div className="mb-1 font-medium text-muted-foreground">
-                            Stage {stageIndex + 1}
-                          </div>
-                          <div className="grid grid-cols-2 gap-2">
-                            <div className="space-y-1">
-                              <div className="text-[10px] tracking-wide text-muted-foreground uppercase">
-                                {stage.from.teeth}T
-                              </div>
-                              {stage.from.skus.map((sku, skuIndex) => (
-                                <Link
-                                  key={skuIndex}
-                                  to={sku.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="block rounded border border-border bg-muted/50 p-1.5 text-[11px] transition-colors hover:bg-muted"
-                                >
-                                  <span className="font-semibold">
-                                    {sku.sku}
-                                  </span>
-                                  <span className="text-muted-foreground">
-                                    {' '}
-                                    - {formatPitch(sku.pitch, sku.family)}{' '}
-                                    {sku.family} ({sku.bore})
-                                  </span>
-                                </Link>
-                              ))}
+                      {gearbox.stages.map((stage, stageIndex) => {
+                        const stageFamilies = [
+                          ...new Set(
+                            [...stage.from.skus, ...stage.to.skus].map((sku) =>
+                              skuFamilyLabel(sku.family),
+                            ),
+                          ),
+                        ];
+                        return (
+                          <div key={stageIndex} className="text-xs">
+                            <div className="mb-1 font-medium text-muted-foreground">
+                              Stage {stageIndex + 1}
+                              {stageFamilies.length > 0 && (
+                                <span className="ml-1 font-normal">
+                                  ({stageFamilies.join(', ')})
+                                </span>
+                              )}
                             </div>
-                            <div className="space-y-1">
-                              <div className="text-[10px] tracking-wide text-muted-foreground uppercase">
-                                {stage.to.teeth}T
+                            <div className="grid grid-cols-2 gap-2">
+                              <div className="space-y-1">
+                                <div className="text-[10px] tracking-wide text-muted-foreground uppercase">
+                                  {stage.from.teeth}T
+                                </div>
+                                {stage.from.skus.map((sku, skuIndex) => (
+                                  <Link
+                                    key={skuIndex}
+                                    to={sku.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="block rounded border border-border bg-muted/50 p-1.5 text-[11px] transition-colors hover:bg-muted"
+                                  >
+                                    <span className="font-semibold">
+                                      {sku.sku}
+                                    </span>
+                                    <span className="text-muted-foreground">
+                                      {' '}
+                                      - {formatPitch(
+                                        sku.pitch,
+                                        sku.family,
+                                      )}{' '}
+                                      {sku.family} ({sku.bore})
+                                    </span>
+                                  </Link>
+                                ))}
                               </div>
-                              {stage.to.skus.map((sku, skuIndex) => (
-                                <Link
-                                  key={skuIndex}
-                                  to={sku.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="block rounded border border-border bg-muted/50 p-1.5 text-[11px] transition-colors hover:bg-muted"
-                                >
-                                  <span className="font-semibold">
-                                    {sku.sku}
-                                  </span>
-                                  <span className="text-muted-foreground">
-                                    {' '}
-                                    - {formatPitch(sku.pitch, sku.family)}{' '}
-                                    {sku.family} ({sku.bore})
-                                  </span>
-                                </Link>
-                              ))}
+                              <div className="space-y-1">
+                                <div className="text-[10px] tracking-wide text-muted-foreground uppercase">
+                                  {stage.to.teeth}T
+                                </div>
+                                {stage.to.skus.map((sku, skuIndex) => (
+                                  <Link
+                                    key={skuIndex}
+                                    to={sku.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="block rounded border border-border bg-muted/50 p-1.5 text-[11px] transition-colors hover:bg-muted"
+                                  >
+                                    <span className="font-semibold">
+                                      {sku.sku}
+                                    </span>
+                                    <span className="text-muted-foreground">
+                                      {' '}
+                                      - {formatPitch(
+                                        sku.pitch,
+                                        sku.family,
+                                      )}{' '}
+                                      {sku.family} ({sku.bore})
+                                    </span>
+                                  </Link>
+                                ))}
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                     </div>
                   </td>
                 </tr>

--- a/playwright-tests/ratio-finder.spec.ts
+++ b/playwright-tests/ratio-finder.spec.ts
@@ -88,4 +88,22 @@ test.describe('Ratio Finder - per-stage transmission type', () => {
     await expect(list.getByText(/Stage 1\s*\([^)]*Belt[^)]*\)/)).toHaveCount(0);
     await expect(list.getByText(/Stage 2\s*\([^)]*Gear[^)]*\)/)).toHaveCount(0);
   });
+
+  test('enabling 3-stage search reveals the Stage 3 filter', async ({
+    page,
+  }) => {
+    // Three-stage is opt-in: the Stage 3 card is hidden until enabled.
+    await expect(page.getByTestId('stage-3-families')).toHaveCount(0);
+
+    await page
+      .getByRole('checkbox', { name: 'Search 3-stage gearboxes (slower)' })
+      .click();
+
+    await expect(page.getByTestId('stage-3-families')).toBeVisible();
+    for (const family of FAMILIES) {
+      await expect(
+        page.getByRole('checkbox', { name: `Stage 3 ${family}` }),
+      ).toBeChecked();
+    }
+  });
 });

--- a/playwright-tests/ratio-finder.spec.ts
+++ b/playwright-tests/ratio-finder.spec.ts
@@ -21,11 +21,13 @@ test.describe('Ratio Finder - per-stage transmission type', () => {
   test('per-stage type filters are visible by default and fully selected', async ({
     page,
   }) => {
-    // The feature is discoverable without opening any menu.
+    // The feature is discoverable without opening any menu; all three stage
+    // filters are shown (Stage 3 applies only to the auto three-stage fallback).
     await expect(page.getByTestId('stage-1-families')).toBeVisible();
     await expect(page.getByTestId('stage-2-families')).toBeVisible();
+    await expect(page.getByTestId('stage-3-families')).toBeVisible();
 
-    for (const stage of ['Stage 1', 'Stage 2']) {
+    for (const stage of ['Stage 1', 'Stage 2', 'Stage 3']) {
       for (const family of FAMILIES) {
         await expect(
           page.getByRole('checkbox', { name: `${stage} ${family}` }),
@@ -89,21 +91,21 @@ test.describe('Ratio Finder - per-stage transmission type', () => {
     await expect(list.getByText(/Stage 2\s*\([^)]*Gear[^)]*\)/)).toHaveCount(0);
   });
 
-  test('enabling 3-stage search reveals the Stage 3 filter', async ({
+  test('auto-falls back to three stages for a ratio two stages cannot reach', async ({
     page,
   }) => {
-    // Three-stage is opt-in: the Stage 3 card is hidden until enabled.
-    await expect(page.getByTestId('stage-3-families')).toHaveCount(0);
+    // A single toothed stage tops out near 14:1, so two stages cannot exceed
+    // ~196:1. Disable planetaries (which can reach high ratios in fewer stages)
+    // and target 250:1 so the three-stage fallback must kick in.
+    await page.getByRole('checkbox', { name: 'Planetaries' }).click();
+    await page.getByTestId('reduction-magnitude').fill('250');
 
-    await page
-      .getByRole('checkbox', { name: 'Search 3-stage gearboxes (slower)' })
-      .click();
-
-    await expect(page.getByTestId('stage-3-families')).toBeVisible();
-    for (const family of FAMILIES) {
-      await expect(
-        page.getByRole('checkbox', { name: `Stage 3 ${family}` }),
-      ).toBeChecked();
-    }
+    await expect(page.getByTestId('three-stage-notice')).toBeVisible({
+      timeout: COMPUTE_TIMEOUT,
+    });
+    await waitForResults(page);
+    // Every shown gearbox is a three-stage gearbox.
+    const list = page.getByTestId('gearbox-list');
+    await expect(list.getByText(/Stage 3\s*\(/).first()).toBeVisible();
   });
 });

--- a/playwright-tests/ratio-finder.spec.ts
+++ b/playwright-tests/ratio-finder.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const FAMILIES = ['Gear', 'Belt', 'Chain', 'Planetary'] as const;
+
+// The worker loads the full COTS dataset and enumerates thousands of stage
+// combinations, so the first computation can take several seconds.
+const COMPUTE_TIMEOUT = 30_000;
+
+async function waitForResults(page: Page) {
+  await expect(page.getByTestId('gearbox-list')).toBeVisible({
+    timeout: COMPUTE_TIMEOUT,
+  });
+}
+
+test.describe('Ratio Finder - per-stage transmission type', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/ratio-finder');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('per-stage type filters are visible by default and fully selected', async ({
+    page,
+  }) => {
+    // The feature is discoverable without opening any menu.
+    await expect(page.getByTestId('stage-1-families')).toBeVisible();
+    await expect(page.getByTestId('stage-2-families')).toBeVisible();
+
+    for (const stage of ['Stage 1', 'Stage 2']) {
+      for (const family of FAMILIES) {
+        await expect(
+          page.getByRole('checkbox', { name: `${stage} ${family}` }),
+        ).toBeChecked();
+      }
+    }
+  });
+
+  test('restricting both stages to gears removes belt/chain/planetary results', async ({
+    page,
+  }) => {
+    await waitForResults(page);
+    const list = page.getByTestId('gearbox-list');
+
+    for (const stage of ['Stage 1', 'Stage 2']) {
+      for (const family of ['Belt', 'Chain', 'Planetary']) {
+        await page
+          .getByRole('checkbox', { name: `${stage} ${family}` })
+          .click();
+      }
+    }
+
+    // Gears-only solutions must still exist for the default 20:1 target.
+    await expect(list).toContainText('Gear', { timeout: COMPUTE_TIMEOUT });
+    // ...and no belt, chain, or planetary components may appear.
+    await expect(list).not.toContainText('Pulley', {
+      timeout: COMPUTE_TIMEOUT,
+    });
+    await expect(list).not.toContainText('Sprocket', {
+      timeout: COMPUTE_TIMEOUT,
+    });
+    await expect(list).not.toContainText('Planetary', {
+      timeout: COMPUTE_TIMEOUT,
+    });
+  });
+
+  test('stages honor their own type filter positionally (gears then chain)', async ({
+    page,
+  }) => {
+    await waitForResults(page);
+    const list = page.getByTestId('gearbox-list');
+
+    // Stage 1 -> gears only.
+    for (const family of ['Belt', 'Chain', 'Planetary']) {
+      await page.getByRole('checkbox', { name: `Stage 1 ${family}` }).click();
+    }
+    // Stage 2 -> chain only.
+    for (const family of ['Gear', 'Belt', 'Planetary']) {
+      await page.getByRole('checkbox', { name: `Stage 2 ${family}` }).click();
+    }
+
+    // Every resulting two-stage gearbox must run gears into chain. The stage
+    // header renders as "Stage 1(Gear)" (no space before the parenthesis).
+    await expect(list.getByText(/Stage 1\s*\(Gear\)/).first()).toBeVisible({
+      timeout: COMPUTE_TIMEOUT,
+    });
+    await expect(list.getByText(/Stage 2\s*\(Chain\)/).first()).toBeVisible({
+      timeout: COMPUTE_TIMEOUT,
+    });
+    await expect(list.getByText(/Stage 1\s*\([^)]*Belt[^)]*\)/)).toHaveCount(0);
+    await expect(list.getByText(/Stage 2\s*\([^)]*Gear[^)]*\)/)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds automatic three-stage gearbox search to the Ratio Finder and makes the whole finder dramatically faster. Builds on #659 (per-stage transmission-type filters); the first commit here is that PR's content, so this can either supersede #659 or be reviewed after it merges.

### Three-stage gearboxes (automatic)
The finder searches one or two stages as before, and **only falls back to three stages when no one- or two-stage gearbox can reach the target** (e.g. a high reduction, or a tight tooth-range/type filter that rules out shorter gearboxes). When that happens it shows a notice in the results header:

> No one- or two-stage gearbox reaches this ratio with the current filters — showing three-stage options.

There's no toggle to manage — three stages appear exactly when they're the only option. The per-stage transmission-type filters now cover Stage 3 as well (positional: Stage 3 applies only to a third stage).

### ~100x faster finder
The finder previously brute-forced the full ~6,400² tooth grid (~41M combinations), built an object for every near-target pair, then discarded the unbuildable majority. It now:
- builds each stage's **buildable** candidate stages once (only tooth pairs that have real COTS parts), each carrying its matched SKUs;
- finds combinations with a **sorted binary search** (the last stage is a lookup, not a scan);
- keeps three-stage results in a **bounded best-by-error set** so memory stays flat for high ratios;
- only ever builds the third stage on fallback, so normal searches don't pay for it.

Measured at 40:1 on a dev machine: two-stage ~1400ms → ~15ms, three-stage ~1600ms → ~90ms. The default two-stage solution set is byte-identical (worker snapshot unchanged aside from a new flag).

The now-dead per-family `stageFrom*` matchers are replaced by a single teeth-indexed matcher.

## Tests
- Worker unit tests for the per-stage filters, the three-stage auto-fallback, the two-stage ceiling, and positional constraints across a three-stage fallback.
- Playwright tests for the per-stage filters and for a high ratio surfacing the three-stage notice.
- Full suite: 696 unit + 4 ratio-finder e2e green; lint, format, typecheck, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)