### PR TITLE
Fix motor playground reporting >100% efficiency at free speed

### DIFF
--- a/app/lib/math/motors.worker.test.ts
+++ b/app/lib/math/motors.worker.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateMotorCurve } from '~/lib/math/motors.worker';
+import Measurement from '~/lib/models/Measurement';
+import Motor, { ALL_MOTORS } from '~/lib/models/Motor';
+
+const statorLimit = new Measurement(1000, 'A');
+const supplyLimit = new Measurement(1000, 'A');
+const statorVoltage = new Measurement(12, 'V');
+const supplyVoltage = new Measurement(12, 'V');
+
+async function curveFor(motorName: string) {
+  return generateMotorCurve(
+    Motor.fromName(motorName, 1).toDict(),
+    statorLimit.toDict(),
+    supplyLimit.toDict(),
+    statorVoltage.toDict(),
+    supplyVoltage.toDict(),
+  );
+}
+
+describe('generateMotorCurve efficiency', () => {
+  it('never reports efficiency at or above 100%', async () => {
+    // Kraken X60, NEO, and Falcon 500 all have Kt * Kv > 1, which previously
+    // produced efficiencies above 100% near free speed.
+    for (const name of ['Kraken X60', 'NEO', 'Falcon 500']) {
+      const states = await curveFor(name);
+      for (const state of states) {
+        expect(state.efficiency).toBeLessThan(1);
+        expect(state.efficiency).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it('keeps efficiency within [0, 1) for every motor in the library', async () => {
+    for (const spec of ALL_MOTORS) {
+      const states = await curveFor(spec.name);
+      for (const state of states) {
+        expect(
+          state.efficiency,
+          `${spec.name} @ ${state.angularVelocityRPM} rpm`,
+        ).toBeLessThan(1);
+        expect(
+          state.efficiency,
+          `${spec.name} @ ${state.angularVelocityRPM} rpm`,
+        ).toBeGreaterThanOrEqual(0);
+      }
+    }
+  }, 60000);
+
+  it('is ~0% at stall and approaches 0% at free speed', async () => {
+    const states = await curveFor('Kraken X60');
+    expect(states.length).toBeGreaterThan(2);
+
+    // At stall (lowest speed) there is no shaft power, so efficiency is ~0.
+    const first = states[0];
+    expect(first.efficiency).toBeLessThan(0.05);
+
+    // At free speed the current collapses to the free current, so the useful
+    // shaft power (and thus efficiency) returns to ~0.
+    const last = states[states.length - 1];
+    expect(last.efficiency).toBeLessThan(0.1);
+  });
+
+  it('peaks at a sensible efficiency somewhere in the middle of the curve', async () => {
+    const states = await curveFor('Kraken X60');
+    const peak = Math.max(...states.map((s) => s.efficiency));
+    // Brushless FRC motors peak well above 50% but below 100%.
+    expect(peak).toBeGreaterThan(0.5);
+    expect(peak).toBeLessThan(1);
+  });
+});

--- a/app/lib/math/motors.worker.ts
+++ b/app/lib/math/motors.worker.ts
@@ -70,14 +70,32 @@ export async function generateMotorCurve(
     motorSim.setInputVoltage(vApplied.to('V').scalar);
     motorSim.update(SIM_TIMESTEP_SECONDS);
 
-    const inputPower = vApplied.mul(
-      new Measurement(motorSim.getCurrentDraw(), 'A'),
-    );
-    const outputPower = new Measurement(motorSim.getTorque(), 'N m')
-      .mul(w)
-      .removeRad();
+    const currentDraw = new Measurement(motorSim.getCurrentDraw(), 'A');
 
-    const efficiency = outputPower.div(inputPower);
+    // Electrical input power.
+    const inputPower = vApplied.mul(currentDraw);
+
+    // Mechanical shaft power. WPILib's DCMotorSim models a frictionless plant,
+    // so getTorque() returns the electromagnetic torque (Kt * I) rather than the
+    // useful shaft torque, and Kt (derived from stall data) is not consistent
+    // with Kv (derived from free-speed data). Using Kt * I * w for output power
+    // therefore overstates it and yields efficiencies above 100% near free speed
+    // for motors where Kt * Kv > 1.
+    //
+    // Instead, compute shaft power from the back-EMF (w / Kv) acting on the
+    // torque-producing current. The no-load (free) current is subtracted because
+    // it is consumed by internal friction and produces no useful output. This
+    // gives 0% efficiency at stall (w = 0) and at free speed (I = freeCurrent),
+    // and stays strictly below 100% in between (copper and no-load losses are
+    // both accounted for).
+    const backEmf = motor.kV.inverse().mul(w).to('V');
+    const torqueCurrent = currentDraw.sub(motor.freeCurrent);
+    const outputPower = backEmf.mul(torqueCurrent);
+
+    const efficiency =
+      inputPower.baseScalar === 0
+        ? new Measurement(0)
+        : Measurement.max(outputPower.div(inputPower), new Measurement(0));
 
     states.push({
       angularVelocityRPM: parseInt(

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -214,19 +214,24 @@ export default function Home() {
               icon={EmojioneMonotoneChains}
             />
             <CalcCard
+              to="/gears"
+              title="Gears Calculator"
+              icon={Fa7SolidGears}
+            />
+            <CalcCard
               to="/linear"
               title="Linear Mechanism"
               icon={MoveVerticalIcon}
             />
             <CalcCard
-              to="/arm"
-              title="Arm Calculator"
-              icon={StreamlineUltimateFactoryIndustrialRobotArm1}
-            />
-            <CalcCard
               to="/flywheel"
               title="Flywheel Calculator"
               icon={Disc3Icon}
+            />
+            <CalcCard
+              to="/arm"
+              title="Arm Calculator"
+              icon={StreamlineUltimateFactoryIndustrialRobotArm1}
             />
             <CalcCard
               to="/intake"
@@ -239,11 +244,6 @@ export default function Home() {
               icon={SearchIcon}
             />
             <CalcCard to="/ratio" title="Ratio Calculator" icon={RatioIcon} />
-            <CalcCard
-              to="/gears"
-              title="Gears Calculator"
-              icon={Fa7SolidGears}
-            />
           </div>
         </section>
 


### PR DESCRIPTION
```
The /motors efficiency curve used getTorque() * w / (V * I) for efficiency. WPILib's frictionless DCMotorSim returns getTorque() = Kt * I, so the formula reduced to Kt * w / V, which reaches ~Kt*Kv at free speed. Because Kt (from stall data) and Kv (from free-speed data) are not ideally consistent, motors with Kt*Kv > 1 (Kraken X60, NEO, Falcon 500) read just over 100%.

Compute shaft power from back-EMF (w / Kv) acting on the torque-producing current (I - freeCurrent) instead, accounting for both copper and no-load losses. Efficiency is now 0% at stall, 0% at free speed, peaks in between, and stays strictly below 100% for every motor. Adds a divide-by-zero guard and a unit test asserting efficiency stays in [0, 1).

Also reorder the home page calculator cards (Gears moved up).
```